### PR TITLE
run source node

### DIFF
--- a/src/noob/node/base.py
+++ b/src/noob/node/base.py
@@ -6,6 +6,7 @@ from typing import Any, ClassVar, Generic, ParamSpec, TypeVar, Unpack
 
 from pydantic import BaseModel, Field
 
+from noob.event import Event
 from noob.utils import resolve_python_identifier
 
 if sys.version_info < (3, 11) or sys.version_info < (3, 12):
@@ -176,7 +177,7 @@ class Edge(BaseModel):
         Return some unique string that represents the dependency
 
         NodeA.signal2
-        NodeA.signal2[type=gather,n=5]
+        NodeA.signal2[type=gather,n=5]  --> we aren't doing this anymore if edge operations are now separate nodes.
         """
 
     def update(self, events: list[Event]) -> None:

--- a/src/noob/store.py
+++ b/src/noob/store.py
@@ -59,7 +59,7 @@ class EventStore:
         event = [e for e in self.events if e["node_id"] == node_id and e["slot"] == slot]
         return None if len(event) == 0 else event[-1]
 
-    def gather(self, edges: list[Edge]) -> dict | None:
+    def gather(self, edges: list[Edge]) -> dict:
         """
         Gather events into a form that can be consumed by a :meth:`.Node.process` method,
         given the collection of inbound edges (usually from :meth:`.Tube.in_edges` ).
@@ -82,7 +82,7 @@ class EventStore:
             value = None if event is None else event["value"]
             ret[edge.target_slot] = value
 
-        return None if not ret or all(val is None for val in ret.values()) else ret
+        return ret
 
     def clear(self) -> None:
         """

--- a/tests/data/pipelines/depends.yaml
+++ b/tests/data/pipelines/depends.yaml
@@ -16,7 +16,7 @@ nodes:
     type: concat
     depends:
     - count_source.counts
-    - count_source.other_value
+    - count_source.words
   dep_gather_dependent:
     type: noob.testing.dictify
     depends:


### PR DESCRIPTION
trying to get the source nodes to run, but need review since my understanding across the entire current codebase is still incomplete :/

## details

1. no more valid input check in `Runner`. all inputs get passed to node immediately.
2. the source examples so far return `Generator` types, as opposed to the actual return value.
3. so I used `inspect.isgenerator` for the source check, and
4. `typing.get_args(inspect.signature(node.fn).return_annotation.__args__[0])[1].name` to get the `Annotated` name from the `Name` instance.
5. the value gets injected to `store` as `{name: value}`.


## discussion

it feels... wanting ngl. could we clarify what the vision on using generators for source examples is, @sneakers-the-rat ?



next target would be getting the subsequent nodes to run by defining `_init_edge` to allow injections from `store` to the next `node`.