### PR TITLE
enabled flag for nodes

### DIFF
--- a/src/noob/node/base.py
+++ b/src/noob/node/base.py
@@ -117,6 +117,8 @@ class Node(BaseModel):
     id: str
     """Unique identifier of the node"""
     spec: NodeSpecification
+    enabled: bool
+    """Whether the node is enabled or not"""
 
     _signals: list[Signal] = None
     _slots: dict[str, Slot] = None
@@ -180,16 +182,17 @@ class Node(BaseModel):
         obj = resolve_python_identifier(spec.type_)
 
         params = spec.params if spec.params is not None else {}
+        enabled = spec.enabled
 
         # check if function by checking if callable -
         # Node classes do not have __call__ defined and thus should not be callable
         if inspect.isclass(obj):
             if issubclass(obj, Node):
-                return obj(id=spec.id, spec=spec, **params)
+                return obj(id=spec.id, spec=spec, enabled=enabled, **params)
             else:
-                return WrapClassNode(id=spec.id, cls=obj, spec=spec, params=params)
+                return WrapClassNode(id=spec.id, cls=obj, spec=spec, params=params, enabled=enabled)
         else:
-            return WrapFuncNode(id=spec.id, fn=obj, spec=spec, params=params)
+            return WrapFuncNode(id=spec.id, fn=obj, spec=spec, params=params, enabled=enabled)
 
     @property
     def signals(self) -> list[Signal]:

--- a/src/noob/node/spec.py
+++ b/src/noob/node/spec.py
@@ -110,3 +110,8 @@ class NodeSpecification(BaseModel):
     parameterized the signature of a function node, or
     by a TypedDict for a class node.
     """
+    enabled: bool = True
+    """
+    If this flag is False, the node will not be initialized 
+    or included in the `:meth:.Tube.graph`.
+    """

--- a/src/noob/runner.py
+++ b/src/noob/runner.py
@@ -124,7 +124,7 @@ class TubeRunner(ABC):
             dict: of the Return sink's key mapped to the returned value,
             None: if there are no :class:`.Return` sinks in the tube
         """
-        ret_nodes = [n for n in self.tube.nodes.values() if isinstance(n, Return)]
+        ret_nodes = [n for n in self.tube.on_nodes.values() if isinstance(n, Return)]
         if not ret_nodes:
             return None
         ret_node = ret_nodes[0]
@@ -184,7 +184,7 @@ class SynchronousRunner(TubeRunner):
             raise AlreadyRunningError("Tube is already running!")
 
         self._running.set()
-        for node in self.tube.nodes.values():
+        for node in self.tube.on_nodes.values():
             node.init()
 
         for asset in self.tube.cube.assets.values():
@@ -195,7 +195,7 @@ class SynchronousRunner(TubeRunner):
     def deinit(self) -> None:
         """Stop all nodes processing"""
         # TODO: lock to ensure we've been started
-        for node in self.tube.nodes.values():
+        for node in self.tube.on_nodes.values():
             node.deinit()
 
         for asset in self.tube.cube.assets.values():

--- a/src/noob/tube.py
+++ b/src/noob/tube.py
@@ -70,6 +70,13 @@ class Tube(BaseModel):
     (i.e. ``edges[0].source_node is nodes[node_id]`` ).
     """
 
+    @property
+    def on_nodes(self) -> dict[str, Node]:
+        """
+        Produce nodes that have :attr:`.Node.enabled` set to `True`.
+        """
+        return {k: v for k, v in self.nodes.items() if v.enabled}
+
     def graph(self) -> TopologicalSorter:
         """
         Produce a :class:`.TopologicalSorter` based on the graph induced by
@@ -88,7 +95,8 @@ class Tube(BaseModel):
 
         """
         sorter = TopologicalSorter()
-        for node_id in self.nodes:
+        enabled_nodes = [node_id for node_id, node in self.nodes.items() if node.enabled]
+        for node_id in enabled_nodes:
             required_edges = [
                 e.source_node for e in self.edges if e.target_node == node_id and e.required
             ]

--- a/tests/data/pipelines/enable_flag.yaml
+++ b/tests/data/pipelines/enable_flag.yaml
@@ -1,0 +1,24 @@
+noob_id: testing-enable-flag
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.1.1.dev138+ge1b5e7f.d20250905
+nodes:
+  a:
+    type: noob.testing.count_source
+  b:
+    type: noob.testing.multiply
+    depends:
+      - left: a.index
+  c:
+    type: return
+    depends: b.value
+    enabled: False
+  sink_on:
+    type: noob.testing.divide
+    depends:
+      - b.value
+    enabled: True
+  sink_off:
+    type: noob.testing.divide
+    depends:
+      - b.value
+    enabled: False

--- a/tests/node/test_generator.py
+++ b/tests/node/test_generator.py
@@ -3,7 +3,9 @@ from collections.abc import Generator
 from noob.node import Node, NodeSpecification, process_method
 from noob.node.base import WrapClassNode, WrapFuncNode
 
-_annoying_kwargs = dict(id="gen-node", spec=NodeSpecification(type="a.b", id="zzz"))
+_annoying_kwargs = dict(
+    id="gen-node", enabled=True, spec=NodeSpecification(type="a.b", id="zzz", enabled=True)
+)
 
 
 def test_subclass_generator():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,6 +2,9 @@ from noob import SynchronousRunner, Tube
 
 
 def test_process_callback() -> None:
+    """
+    callbacks must take place after each event emission.
+    """
 
     tube = Tube.from_specification("testing-basic")
     runner = SynchronousRunner(tube)
@@ -17,3 +20,13 @@ def test_process_callback() -> None:
     runner.process()
 
     assert len(events) == 2
+
+
+def test_disabled_nodes() -> None:
+    tube = Tube.from_specification("testing-enable-flag")
+    runner = SynchronousRunner(tube)
+
+    runner.init()
+    assert set(runner.tube.on_nodes.keys()) == {"a", "b", "sink_on"}
+    result = runner.process()
+    assert result is None


### PR DESCRIPTION
need enabled flag for nodes to allow optional nodes in the pipeline extensions (i.e. postprocessing nodes for GUI)

works in spec as following:

```yaml
nodes:
  on:
    type: noob.testing.func_a
    depends:
      - ...
    enabled: True
  off:
    type: noob.testing.func_b
    depends:
      - ...
    enabled: False
```
nodes with `enabled: off` are not initialized by `runner` or included in `tube`'s graph construction.