### PR TITLE
Add tube and node inputs

### DIFF
--- a/src/noob/const.py
+++ b/src/noob/const.py
@@ -1,2 +1,2 @@
-RESERVED_IDS = ("input",)
+RESERVED_IDS = ("assets", "input",)
 """Reserved strings that can't be used as IDs for Nodes, etc."""

--- a/src/noob/const.py
+++ b/src/noob/const.py
@@ -1,0 +1,2 @@
+RESERVED_IDS = ("input",)
+"""Reserved strings that can't be used as IDs for Nodes, etc."""

--- a/src/noob/const.py
+++ b/src/noob/const.py
@@ -1,2 +1,5 @@
-RESERVED_IDS = ("assets", "input",)
+RESERVED_IDS = (
+    "assets",
+    "input",
+)
 """Reserved strings that can't be used as IDs for Nodes, etc."""

--- a/src/noob/exceptions.py
+++ b/src/noob/exceptions.py
@@ -24,6 +24,10 @@ class RunnerError(NoobError):
     """Base runner error type"""
 
 
+class InputError(NoobError):
+    """Error with tube input"""
+
+
 # --------------------------------------------------
 # Actual error types you should use
 # --------------------------------------------------
@@ -38,4 +42,10 @@ class ConfigMismatchError(ConfigError, ValueError):
 class AlreadyRunningError(RunnerError, RuntimeError):
     """
     A tube is already running!
+    """
+
+
+class InputMissingError(InputError, ValueError):
+    """
+    A requested input was not provided in the given scope
     """

--- a/src/noob/exceptions.py
+++ b/src/noob/exceptions.py
@@ -2,6 +2,10 @@ class NoobError(Exception):
     """Base exception type"""
 
 
+class NoobWarning(UserWarning):
+    """Base warning type"""
+
+
 # -----------------------------------------------------
 # Top-level error categories
 # use these as a mixin with another base exception type
@@ -28,6 +32,10 @@ class InputError(NoobError):
     """Error with tube input"""
 
 
+class InputWarning(NoobWarning):
+    """Warning with tube input"""
+
+
 # --------------------------------------------------
 # Actual error types you should use
 # --------------------------------------------------
@@ -48,4 +56,17 @@ class AlreadyRunningError(RunnerError, RuntimeError):
 class InputMissingError(InputError, ValueError):
     """
     A requested input was not provided in the given scope
+    """
+
+
+class ExtraInputError(InputError, ValueError):
+    """
+    Extra input was provided in some scope where it was not specified
+    """
+
+
+class ExtraInputWarning(InputWarning, RuntimeWarning):
+    """
+    Extra input was provided in some scope where it was not specified,
+    but it was ignorable
     """

--- a/src/noob/input.py
+++ b/src/noob/input.py
@@ -1,0 +1,109 @@
+import re
+from collections import ChainMap, defaultdict
+from enum import StrEnum
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, Field, PrivateAttr
+
+from noob.exceptions import InputMissingError
+from noob.node.base import Edge
+from noob.types import AbsoluteIdentifier, PythonIdentifier
+
+
+class InputScope(StrEnum):
+    """The scope that input must be provided in"""
+
+    tube = "tube"
+    process = "process"
+
+
+class InputSpecification(BaseModel):
+    """
+    Specification of inputs to a noob tube.
+
+    Inputs can be supplied at different times and frequencies,
+    as specified by `scope`:
+
+    - `tube`: When instantiating the tube
+    - `process`: Per call to :meth:`.TubeRunner.process`
+
+    `tube`-scoped inputs may be used in a node's `param` specification,
+    and `process`-scoped inputs may be used as one of a node's `depends`.
+
+    Inputs can be supplied at a "higher" scope and be accessed by lower scopes:
+    e.g. input requested with a process scope can use input provided when instantiating the tube,
+    if not provided to process but provided to the tube.
+    """
+
+    id: PythonIdentifier
+    type_: AbsoluteIdentifier = Field(..., alias="type")
+    scope: InputScope = InputScope.tube
+
+
+class InputCollection(BaseModel):
+    """
+    A collection of input specifications used during runtime, split by scope,
+    to validate presence of and to combine inputs.
+    """
+
+    INPUT_PATTERN: ClassVar[re.Pattern] = re.compile(r"input\.(?P<key>.*)")
+
+    specs: dict[InputScope, dict[PythonIdentifier, InputSpecification]] = Field(
+        default_factory=lambda: defaultdict(dict)
+    )
+
+    # store long-lived scope inputs
+    _input: dict[InputScope, dict] = PrivateAttr(default_factory=lambda: defaultdict(dict))
+    _chain: ChainMap | None = None
+
+    @property
+    def chain(self) -> ChainMap:
+        """
+        Make a chainmap of inputs at different scopes
+
+        (for possible expansion of number of scopes, to e.g. a runner scope)
+        """
+        if self._chain is None:
+            self._chain = ChainMap(self._input[InputScope.tube])
+        return self._chain
+
+    def get(self, key: str, input: dict | None = None) -> Any:
+        """Get a value from the inputs at any scope, if present"""
+        if input is None:
+            input = {}
+        return self.chain.new_child(input)[key]
+
+    def get_node_params(self, params: dict) -> dict:
+        """Get tube-scoped params specified as inputs needed when instantiating a node"""
+        raise NotImplementedError()
+
+    def collect(self, edges: list[Edge], input: dict) -> dict:
+        raise NotImplementedError()
+
+    def add_input(self, scope: InputScope, input: dict) -> None:
+        """Add some scope's input to the input collection."""
+        if scope == InputScope.process:
+            raise ValueError("Can't store process-scoped input, since it is ephemeral")
+
+        if isinstance(scope, str) and scope in InputScope.__members__:
+            scope = getattr(InputScope, scope)
+
+        if not isinstance(scope, InputScope):
+            raise ValueError(f"Unknown scope: {scope}")
+
+        new = {**self._input[scope], **input}
+        self.validate_presence(scope, new)
+        self._input[scope] = new
+        self._chain = None
+
+    def validate_presence(self, scope: InputScope, *args: dict) -> None:
+        """Check that the required inputs are present in one of several input dicts"""
+        chain = self.chain.new_child()
+        for input in args:
+            chain = chain.new_child(input)
+
+        for spec in self.specs[scope].values():
+            if spec.id not in chain:
+                raise InputMissingError(
+                    f"Requested input {spec.id} not present in inputs at scope {scope.value}"
+                )

--- a/src/noob/node/base.py
+++ b/src/noob/node/base.py
@@ -189,6 +189,15 @@ class Node(BaseModel):
         params = spec.params if spec.params is not None else {}
         if input_collection:
             params = input_collection.get_node_params(params)
+        elif params:
+            from noob.input import InputCollection
+
+            if any(
+                InputCollection.INPUT_PATTERN.fullmatch(v)
+                for v in params.values()
+                if isinstance(v, str)
+            ):
+                raise ValueError("No input collection supplied, but inputs specified in params")
 
         # check if function by checking if callable -
         # Node classes do not have __call__ defined and thus should not be callable

--- a/src/noob/node/base.py
+++ b/src/noob/node/base.py
@@ -2,7 +2,7 @@ import functools
 import inspect
 from collections.abc import Callable, Generator
 from types import GeneratorType, GenericAlias, NoneType, UnionType
-from typing import Annotated, Any, TypeVar, get_args, get_origin
+from typing import TYPE_CHECKING, Annotated, Any, TypeVar, Union, get_args, get_origin
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
@@ -10,9 +10,8 @@ from noob.introspection import is_optional, is_union
 from noob.node.spec import NodeSpecification
 from noob.utils import resolve_python_identifier
 
-"""
-Output Type typevar
-"""
+if TYPE_CHECKING:
+    from noob.input import InputCollection
 
 
 class Slot(BaseModel):
@@ -175,7 +174,9 @@ class Node(BaseModel):
         raise NotImplementedError()
 
     @classmethod
-    def from_specification(cls, spec: "NodeSpecification") -> "Node":
+    def from_specification(
+        cls, spec: "NodeSpecification", input_collection: Union["InputCollection", None] = None
+    ) -> "Node":
         """
         Create a node from its spec
 
@@ -186,6 +187,8 @@ class Node(BaseModel):
         obj = resolve_python_identifier(spec.type_)
 
         params = spec.params if spec.params is not None else {}
+        if input_collection:
+            params = input_collection.get_node_params(params)
 
         # check if function by checking if callable -
         # Node classes do not have __call__ defined and thus should not be callable

--- a/src/noob/runner.py
+++ b/src/noob/runner.py
@@ -48,7 +48,7 @@ class TubeRunner(ABC):
         The `process` method normally does not return anything,
         except when using the special :class:`.Return` node
 
-        Process-scoped `input`s can be passed as kwargs.
+        Process-scoped ``input`` s can be passed as kwargs.
         """
 
     @abstractmethod
@@ -235,7 +235,7 @@ class SynchronousRunner(TubeRunner):
         Iterate through nodes in topological order,
         calling their process method and passing events as they are emitted.
 
-        Process-scoped `input`s can be passed as kwargs.
+        Process-scoped ``input`` s can be passed as kwargs.
         """
         input = self.tube.input_collection.validate_input(InputScope.process, kwargs)
         self.store.clear()

--- a/src/noob/store.py
+++ b/src/noob/store.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from itertools import count
 from typing import Any
 
+from noob.const import RESERVED_IDS
 from noob.event import Event
 from noob.node import Edge
 from noob.node.base import Signal
@@ -88,7 +89,8 @@ class EventStore:
         """
         args = {}
         for edge in edges:
-            if edge.source_node != "assets":
+            # FIXME: use reserved names in validation so we don't need this check
+            if edge.source_node not in RESERVED_IDS:
                 event = self.get(edge.source_node, edge.source_signal)
                 value = None if event is None else event["value"]
                 args[edge.target_slot] = value

--- a/src/noob/tube.py
+++ b/src/noob/tube.py
@@ -170,7 +170,7 @@ class Tube(BaseModel):
         # check inputs first to avoid doing work if the input is invalid
         input_collection = cls._init_inputs(spec)
         # adding the input validates presence of required inputs
-        input_collection.validate_presence(InputScope.tube, input)
+        input_collection.add_input(InputScope.tube, input)
 
         nodes = cls._init_nodes(spec, input_collection)
         edges = cls._init_edges(spec.nodes, nodes)

--- a/src/noob/types.py
+++ b/src/noob/types.py
@@ -8,6 +8,8 @@ from typing import Annotated, Any, TypeAlias
 
 from pydantic import AfterValidator, Field, TypeAdapter
 
+from noob.const import RESERVED_IDS
+
 if sys.version_info < (3, 13):
     from typing_extensions import TypeIs
 else:
@@ -50,10 +52,17 @@ def _is_absolute_identifier(val: str) -> str:
     return val
 
 
+def _not_reserved(val: str) -> str:
+    assert val not in RESERVED_IDS, f"Cannot used reserved ID {val}"
+    return val
+
+
 Range: TypeAlias = tuple[int, int] | tuple[float, float]
-PythonIdentifier: TypeAlias = Annotated[str, AfterValidator(_is_identifier)]
+PythonIdentifier: TypeAlias = Annotated[
+    str, AfterValidator(_is_identifier), AfterValidator(_not_reserved)
+]
 """
-A single valid python identifier.
+A single valid python identifier and not one of the reserved identifiers.
 
 See: https://docs.python.org/3.13/library/stdtypes.html#str.isidentifier
 """
@@ -72,6 +81,8 @@ ConfigSource: TypeAlias = Path | PathLike[str] | ConfigID
 """
 Union of all types of config sources
 """
+NodeID: TypeAlias = Annotated[str, AfterValidator(_is_identifier)]
+
 ReturnNodeType: TypeAlias = None | dict[str, Any] | Any
 
 

--- a/tests/data/pipelines/input_mixed.yaml
+++ b/tests/data/pipelines/input_mixed.yaml
@@ -1,0 +1,31 @@
+noob_id: testing-input-mixed
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.0.1.dev155+g2f9639f
+input:
+  start:
+    scope: tube
+    type: int
+  multiply_tube:
+    scope: tube
+    type: int
+  multiply_process:
+    scope: process
+    type: int
+nodes:
+  a:
+    type: noob.testing.count_source
+    params:
+      start: input.start
+  b:
+    type: noob.testing.multiply
+    depends:
+    - left: a.index
+    - right: input.multiply_tube
+  c:
+    type: noob.testing.multiply
+    depends:
+    - left: b.value
+    - right: input.multiply_process
+  d:
+    type: return
+    depends: c.value

--- a/tests/data/pipelines/input_process_depends.yaml
+++ b/tests/data/pipelines/input_process_depends.yaml
@@ -1,0 +1,20 @@
+noob_id: testing-input-process-depends
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.0.1.dev155+g2f9639f
+
+input:
+  multiply_right:
+    scope: process
+    type: int
+
+nodes:
+  a:
+    type: noob.testing.count_source
+  b:
+    type: noob.testing.multiply
+    depends:
+    - left: a.index
+    - right: input.multiply_right
+  c:
+    type: return
+    depends: b.value

--- a/tests/data/pipelines/input_process_params.yaml
+++ b/tests/data/pipelines/input_process_params.yaml
@@ -1,0 +1,15 @@
+noob_id: testing-input-process-params
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.0.1.dev155+g2f9639f
+input:
+  start:
+    scope: process
+    type: int
+nodes:
+  a:
+    type: noob.testing.count_source
+    params:
+      start: input.start
+  return:
+    type: return
+    depends: a.index

--- a/tests/data/pipelines/input_tube_depends.yaml
+++ b/tests/data/pipelines/input_tube_depends.yaml
@@ -1,0 +1,19 @@
+noob_id: testing-input-tube-depends
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.0.1.dev155+g2f9639f
+input:
+  multiply_right:
+    scope: tube
+    type: int
+
+nodes:
+  a:
+    type: noob.testing.count_source
+  b:
+    type: noob.testing.multiply
+    depends:
+    - left: a.index
+    - right: input.multiply_right
+  c:
+    type: return
+    depends: b.value

--- a/tests/data/pipelines/input_tube_params.yaml
+++ b/tests/data/pipelines/input_tube_params.yaml
@@ -1,0 +1,15 @@
+noob_id: testing-input-tube-params
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.0.1.dev155+g2f9639f
+input:
+  start:
+    scope: tube
+    type: int
+nodes:
+  a:
+    type: noob.testing.count_source
+    params:
+      start: input.start
+  return:
+    type: return
+    depends: a.index

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.mark.xfail
+def test_node_missing_param_input():
+    """
+    When a node specifies an input in its params, but is not provided an input collection,
+    it raises an error.
+    """
+    raise NotImplementedError()

--- a/tests/test_pipelines/test_input.py
+++ b/tests/test_pipelines/test_input.py
@@ -1,0 +1,50 @@
+import pytest
+
+
+@pytest.mark.xfail
+def test_tube_input_params():
+    raise NotImplementedError()
+
+
+@pytest.mark.xfail
+def test_tube_input_depends():
+    """tube-scoped input can be used as depends"""
+    raise NotImplementedError()
+
+
+@pytest.mark.xfail
+def test_process_input_params():
+    """process-scoped input can NOT be used as params"""
+    raise NotImplementedError()
+
+
+@pytest.mark.xfail
+def test_process_input_depends():
+    """process-scoped input can be used as params"""
+    raise NotImplementedError()
+
+
+@pytest.mark.xfail
+def test_tube_input_missing():
+    """Input scoped as tube input raises an error when missing"""
+    raise NotImplementedError()
+
+
+@pytest.mark.xfail
+def test_process_input_missing():
+    """Input scoped as process input raises an error when missing"""
+    raise NotImplementedError()
+
+
+@pytest.mark.xfail
+def test_scope_chaining():
+    """Inputs from an outer scope should be accessible from an inner scope"""
+    raise NotImplementedError()
+
+
+@pytest.mark.xfail
+def test_scope_overrides():
+    """
+    When a tube-scoped input is provided in both the process and tube input, the process overrides.
+    """
+    raise NotImplementedError()

--- a/tests/test_pipelines/test_input.py
+++ b/tests/test_pipelines/test_input.py
@@ -1,50 +1,93 @@
 import pytest
 
+from noob import SynchronousRunner, Tube
+from noob.exceptions import ExtraInputWarning, InputMissingError
 
-@pytest.mark.xfail
+
 def test_tube_input_params():
-    raise NotImplementedError()
+    """tube-scoped input can be used as params"""
+    tube = Tube.from_specification("testing-input-tube-params", input={"start": 7})
+    runner = SynchronousRunner(tube)
+
+    outputs = runner.run(n=5)
+    assert len(outputs) == 5
+    assert outputs == [7, 8, 9, 10, 11]
 
 
-@pytest.mark.xfail
 def test_tube_input_depends():
     """tube-scoped input can be used as depends"""
-    raise NotImplementedError()
+    tube = Tube.from_specification("testing-input-tube-depends", input={"multiply_right": 7})
+    runner = SynchronousRunner(tube)
+
+    outputs = runner.run(n=5)
+    assert len(outputs) == 5
+    assert outputs == [i * 7 for i in range(5)]
 
 
-@pytest.mark.xfail
 def test_process_input_params():
     """process-scoped input can NOT be used as params"""
-    raise NotImplementedError()
+    with (
+        pytest.raises(InputMissingError),
+        pytest.warns(ExtraInputWarning, match=r"Ignoring extra.*"),
+    ):
+        Tube.from_specification("testing-input-process-params", input={"start": 7})
 
 
-@pytest.mark.xfail
 def test_process_input_depends():
-    """process-scoped input can be used as params"""
-    raise NotImplementedError()
+    """process-scoped input can be used as depends"""
+    tube = Tube.from_specification("testing-input-process-depends")
+    runner = SynchronousRunner(tube)
+
+    for left, right in zip(range(5), range(5, 10)):
+        assert runner.process(multiply_right=right) == left * right
 
 
-@pytest.mark.xfail
-def test_tube_input_missing():
+@pytest.mark.parametrize("tube", ("testing-input-tube-params", "testing-input-tube-depends"))
+def test_tube_input_missing(tube):
     """Input scoped as tube input raises an error when missing"""
-    raise NotImplementedError()
+    with pytest.raises(InputMissingError):
+        Tube.from_specification(tube)
+
+    with (
+        pytest.raises(InputMissingError),
+        pytest.warns(ExtraInputWarning, match=r"Ignoring extra.*"),
+    ):
+        Tube.from_specification(tube, input={"irrelevant": 7})
 
 
-@pytest.mark.xfail
-def test_process_input_missing():
+@pytest.mark.parametrize("tube", ("testing-input-process-depends",))
+def test_process_input_missing(tube):
     """Input scoped as process input raises an error when missing"""
-    raise NotImplementedError()
+    tube = Tube.from_specification("testing-input-process-depends")
+    runner = SynchronousRunner(tube)
+
+    with pytest.raises(InputMissingError):
+        runner.process()
+
+    with (
+        pytest.raises(InputMissingError),
+        pytest.warns(ExtraInputWarning, match=r"Ignoring extra.*"),
+    ):
+        runner.process(irrelevant=1)
+
+    # nodes were not run
+    assert runner.process(multiply_right=10) == 0
 
 
-@pytest.mark.xfail
-def test_scope_chaining():
-    """Inputs from an outer scope should be accessible from an inner scope"""
-    raise NotImplementedError()
-
-
-@pytest.mark.xfail
-def test_scope_overrides():
+def test_input_integration():
     """
-    When a tube-scoped input is provided in both the process and tube input, the process overrides.
+    All the different forms of input can be used together
     """
-    raise NotImplementedError()
+    start = 7
+    multiply_tube = 13
+    multiply_process = 17
+    tube = Tube.from_specification(
+        "testing-input-mixed", input={"start": start, "multiply_tube": multiply_tube}
+    )
+
+    runner = SynchronousRunner(tube)
+
+    for i in range(5):
+        this_process = multiply_process * 2 * (i + 1)
+        expected = (start + i) * multiply_tube * this_process
+        assert runner.process(multiply_process=this_process) == expected


### PR DESCRIPTION
Fix: #47 

Initially was doing a runner scope, but realized that this wouldn't really be possible for params since the nodes would have already been instantiated so i scrapped it, but now i'm realizing we could do runner-scoped inputs if they were just a dependency rather than a param.

anyway it is the thing in 47, but not quite done yet so opening as draft