### PR TITLE
Validate dependencies in node and tube specs

### DIFF
--- a/src/noob/types.py
+++ b/src/noob/types.py
@@ -58,6 +58,17 @@ def _is_absolute_identifier(val: str) -> str:
     return val
 
 
+def _is_signal_slot(val: str) -> str:
+    """is a {node}.{signal/slot} identifier"""
+    parts = val.split(".")
+    assert len(parts) == 2, "Must be a {node}.{signal} identifier"
+    assert parts[0] != "", "Must specify a node id"
+    assert parts[1] != "", "Must specify a signal"
+    _is_identifier(parts[0])
+    _is_identifier(parts[1])
+    return val
+
+
 def _not_reserved(val: str) -> str:
     assert val not in RESERVED_IDS, f"Cannot used reserved ID {val}"
     return val
@@ -78,6 +89,13 @@ AbsoluteIdentifier: TypeAlias = Annotated[str, AfterValidator(_is_absolute_ident
 OR 
 - a name of a builtin function/type
 """
+DependencyIdentifier: TypeAlias = Annotated[str, AfterValidator(_is_signal_slot)]
+"""
+A {node_id}.{signal} identifier. 
+
+The `node_id` part must be a valid {class}`.PythonIdentifier` .
+"""
+
 
 ConfigID: TypeAlias = Annotated[str, Field(pattern=CONFIG_ID_PATTERN)]
 """

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,68 @@
+import pytest
+from pydantic import ValidationError
+
+from noob.asset import AssetScope, AssetSpecification
+from noob.input import InputScope, InputSpecification
+from noob.node.spec import NodeSpecification
+from noob.tube import TubeSpecification
+
+
+@pytest.mark.parametrize("dep", ["assets.fake", "input.fake", "fake.value"])
+@pytest.mark.parametrize("form", ["string", "list[str]", "list[dict]"])
+def test_dependencies_exist(dep, form):
+    """Nodes, assets, and inputs that are depended on should exist"""
+    if form == "list[str]":
+        dep = [dep]
+    elif form == "list[dict]":
+        dep = [{"value": dep}]
+
+    with pytest.raises(ValidationError, match=r".*does not exist.*"):
+        TubeSpecification(
+            nodes={"mynode": NodeSpecification(type="list", id="mynode", depends=dep)}
+        )
+
+
+@pytest.mark.parametrize(
+    "spec",
+    (
+        {"nodes": {"right": NodeSpecification(id="wrong", type="list")}},
+        {"input": {"right": InputSpecification(id="wrong", type="list", scope=InputScope.tube)}},
+        {"assets": {"right": AssetSpecification(id="wrong", type="list", scope=AssetScope.RUNNER)}},
+    ),
+)
+def test_id_mismatch(spec):
+    """
+    An ID in an instantiated node specification should be the same as the key used in the nodes dict
+    """
+    with pytest.raises(ValidationError, match=r"Mismatch between id.*"):
+        TubeSpecification(**spec)
+
+
+@pytest.mark.parametrize(
+    "dep",
+    (
+        "list",
+        ".relative",
+        "node.",
+        "some.absolute.python.Identifier",
+        "module:function",
+    ),
+)
+@pytest.mark.parametrize("form", ["string", "list[str]", "list[dict]"])
+def test_signal_identifier(dep, form):
+    """Dependencies should have a {node}.{signal} identifier form"""
+    if form == "list[str]":
+        dep = [dep]
+    elif form == "list[dict]":
+        dep = [{"value": dep}]
+
+    with pytest.raises(ValidationError):
+        NodeSpecification(type="list", id="mynode", depends=dep)
+
+
+def test_slots_unique():
+    """
+    Slots in a dependency spec should be unique
+    """
+    with pytest.raises(ValidationError, match=r"Duplicate.*"):
+        NodeSpecification(type="list", id="mynode", depends=[{"a": "b.value"}, {"a": "c.value"}])


### PR DESCRIPTION
Addresses comment within https://github.com/miniscope/noob/issues/49 , but doesn't address the overall issue of ensuring errors are sensibly bubbled up from tubes.

Adds validation for
- nodes should exist when they are depended on
- slots within a nodes dependencies should be unique (not specified twice)
- outer node/asset/input ids should match inner ids when making a spec programmatically. (i.e. a spec shouldn't be like

  ```yaml
  nodes:
    real_name:
      id: fake_name
      # ...
  ```
- strings within deps are `{node_id}.{signal}` strings instead of any absolute identifier. 

Does *not* check that the *signals* on a depended-on node exist, as that would require loading/inspecting all the code objects in the tube. that should be done when the runner inits/via some additional opt-in "strict" validation mode.

