### PR TITLE
Logger Dir Debug

### DIFF
--- a/src/noob/config.py
+++ b/src/noob/config.py
@@ -21,6 +21,8 @@ class LogConfig(BaseModel):
     Configuration for logging
     """
 
+    model_config = SettingsConfigDict(validate_default=True)
+
     level: LOG_LEVELS = "INFO"
     """
     Severity of log messages to process.


### PR DESCRIPTION
A few options in terms of how to implement `NoEvent`...

A. `NOEVENT = object()`: widely used. type annotation nightmare. tried `NewType` but `NewType` started bullying Pydantic when it became `Union` with other types, and nobody got a time for that.
B. a bare `NoEvent` class: feels weird. might accidentally instantiate it. also a hurdle in type annotation.
C. Singleton `NoEvent` class:
  1. Implementing a separate `Singleton` metaclass
  2. a `NoEvent` base class
  3. ???
  4. Profit

Not sure how this plays out with serialization still.

https://stackoverflow.com/questions/6760685/what-is-the-best-way-of-implementing-a-singleton-in-python