### PR TITLE
no event verse 2

### DIFF
--- a/src/noob/event.py
+++ b/src/noob/event.py
@@ -8,6 +8,8 @@ if sys.version_info < (3, 12):
 else:
     from typing import TypedDict
 
+from noob.types import Singleton
+
 
 class Event(TypedDict):
     """
@@ -49,7 +51,7 @@ class MetaEvent(Event):
     signal: MetaEventType  # type: ignore
 
 
-class NoEvent:
+class NoEvent(metaclass=Singleton):
     """
     Signifier for no event emitted
 

--- a/src/noob/event.py
+++ b/src/noob/event.py
@@ -8,8 +8,6 @@ if sys.version_info < (3, 12):
 else:
     from typing import TypedDict
 
-from noob.types import Singleton
-
 
 class Event(TypedDict):
     """
@@ -51,10 +49,5 @@ class MetaEvent(Event):
     signal: MetaEventType  # type: ignore
 
 
-class NoEvent(metaclass=Singleton):
-    """
-    Signifier for no event emitted
-
-    """
-
-    pass
+class MetaSignal(StrEnum):
+    NoEvent = "NoEvent"

--- a/src/noob/node/gather.py
+++ b/src/noob/node/gather.py
@@ -4,7 +4,7 @@ from typing import Any, Generic, TypeVar
 
 from pydantic import PrivateAttr
 
-from noob.event import NoEvent
+from noob.event import MetaSignal
 from noob.node.base import Node
 
 _TInput = TypeVar("_TInput")
@@ -44,7 +44,7 @@ class Gather(Node, Generic[_TInput]):
     _items: list[_TInput] = PrivateAttr(default_factory=list)
     _lock: LockType = PrivateAttr(default_factory=Lock)
 
-    def process(self, value: _TInput, trigger: Any | None = None) -> list[_TInput] | NoEvent:
+    def process(self, value: _TInput, trigger: Any | None = None) -> list[_TInput] | MetaSignal:
         """Collect value in a list, emit if `n` is met or `trigger` is present"""
         if trigger is not None and self.n is not None:
             raise ValueError("Cannot use trigger mode while `n` is set")
@@ -56,7 +56,7 @@ class Gather(Node, Generic[_TInput]):
                 finally:
                     # clear list after returning
                     self._items = []
-            return NoEvent()
+            return MetaSignal.NoEvent
 
     def _should_return(self, trigger: Any | None) -> bool:
         return (self.n is not None and len(self._items) >= self.n) or (

--- a/src/noob/node/return_.py
+++ b/src/noob/node/return_.py
@@ -4,7 +4,7 @@ Special Return sink that tube runners use to return values from :meth:`.TubeRunn
 
 from typing import Any
 
-from noob.event import NoEvent
+from noob.event import MetaSignal
 from noob.node.base import Node, Slot
 
 
@@ -16,7 +16,7 @@ class Return(Node):
     _args: tuple | None = None
     _kwargs: dict | None = None
 
-    def process(self, *args: Any, **kwargs: Any) -> NoEvent:
+    def process(self, *args: Any, **kwargs: Any) -> MetaSignal:
         """
         Store the incoming value to retrieve later with :meth:`.get`
         """
@@ -30,7 +30,7 @@ class Return(Node):
         else:
             self._kwargs.update(kwargs)
 
-        return NoEvent()
+        return MetaSignal.NoEvent
 
     def get(self, keep: bool) -> Any | None:
         """

--- a/src/noob/store.py
+++ b/src/noob/store.py
@@ -9,7 +9,7 @@ from itertools import count
 from typing import Any
 
 from noob.const import RESERVED_IDS
-from noob.event import Event, NoEvent
+from noob.event import Event, MetaSignal
 from noob.node import Edge
 from noob.node.base import Signal
 
@@ -41,7 +41,7 @@ class EventStore:
             node_id (str): ID of the node that emitted the events
             epoch (int): Epoch count that the signal was emitted in
         """
-        if isinstance(value, NoEvent):
+        if value is MetaSignal.NoEvent:
             return None
         timestamp = datetime.now(UTC)
 

--- a/src/noob/types.py
+++ b/src/noob/types.py
@@ -139,14 +139,3 @@ AbsoluteIdentifierAdapter = TypeAdapter(AbsoluteIdentifier)
 class RunnerContext(TypedDict):
     runner: TubeRunner
     tube: Tube
-
-
-class Singleton(type):
-    _instances: dict = {}
-
-    def __call__(cls, *args: Any, **kwargs: Any):
-        if cls not in cls._instances:
-            cls._instances[cls] = super().__call__(*args, **kwargs)
-        else:
-            cls._instances[cls].__init__(*args, **kwargs)
-        return cls._instances[cls]

--- a/src/noob/types.py
+++ b/src/noob/types.py
@@ -139,3 +139,14 @@ AbsoluteIdentifierAdapter = TypeAdapter(AbsoluteIdentifier)
 class RunnerContext(TypedDict):
     runner: TubeRunner
     tube: Tube
+
+
+class Singleton(type):
+    _instances: dict = {}
+
+    def __call__(cls, *args: Any, **kwargs: Any):
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        else:
+            cls._instances[cls].__init__(*args, **kwargs)
+        return cls._instances[cls]


### PR DESCRIPTION
singing the same verse



A few options in terms of how to implement NoEvent...

A. NOEVENT = object(): widely used. type annotation nightmare. tried NewType but NewType started bullying Pydantic when it became Union with other types, and nobody got a time for that.
B. a bare NoEvent class: feels weird. might accidentally instantiate it. also a hurdle in type annotation.
C. Singleton NoEvent class:

    Implementing a separate Singleton metaclass
    a NoEvent base class
    ???
    Profit

Not sure how this plays out with serialization still.

https://stackoverflow.com/questions/6760685/what-is-the-best-way-of-implementing-a-singleton-in-python
