### PR TITLE
calling async from sync in the most cursed way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,4 @@ docs/_static/js/noob-js*
 
 noob_config.yaml
 noob_config.yml
+prof/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,9 +135,10 @@ addopts = [
     "--timeout=15"
 ]
 markers = [
+    "asyncio: any usage of asyncio",
+    "async_runner: uses the async runner",
     "sync_runner: uses the sync runner",
-    "zmq_runner: uses the zmq runner"
-
+    "zmq_runner: uses the zmq runner",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,6 @@ addopts = [
     "--timeout=15"
 ]
 markers = [
-    "asyncio: any usage of asyncio",
     "async_runner: uses the async runner",
     "sync_runner: uses the sync runner",
     "zmq_runner: uses the zmq runner",

--- a/src/noob/runner/asyncio.py
+++ b/src/noob/runner/asyncio.py
@@ -20,6 +20,11 @@ else:
 class AsyncRunner(TubeRunner):
 
     eventloop: asyncio.AbstractEventLoop | None = None
+    exception_timeout: float = 10
+    """
+    When a node raises an error, wait this long (in seconds)
+    before cancelling the other currently running nodes. 
+    """
 
     def __post_init__(self):
         super().__post_init__()
@@ -27,6 +32,7 @@ class AsyncRunner(TubeRunner):
         self._node_ready = asyncio.Event()
         self._init_lock = asyncio.Lock()
         self._pending_futures = set()
+        self._exception: BaseException | None = None
         if not self.eventloop or self.eventloop.is_closed():
             self.eventloop = asyncio.get_running_loop()
 
@@ -68,6 +74,17 @@ class AsyncRunner(TubeRunner):
         calling their process method and passing events as they are emitted.
 
         Process-scoped ``input`` s can be passed as kwargs.
+
+        We don't want to cancel nodes on the first error,
+        as would happen with a task group.
+        e.g. some nodes might be writing data, and we want that to succeed
+        even if some other node in this generation fails.
+        We also want to schedule nodes opportunistically,
+        as soon as their dependencies are satisfied,
+        without needing to wait for the entire graph generation to finish
+        so we queue as many as we can and use futures/callbacks to signal completion.
+        If a node raises an error, we allow the other running nodes to complete
+        (with some timeout
         """
         self.eventloop = cast(asyncio.AbstractEventLoop, self.eventloop)
         if not self._running.is_set():
@@ -80,21 +97,14 @@ class AsyncRunner(TubeRunner):
         scheduler.add_epoch()
 
         while scheduler.is_active():
+            if self._exception:
+                await self._raise_exception()
             ready = scheduler.get_ready()
             if not ready:
                 # if none are ready, wait until another node is complete and check again
                 self._node_ready.clear()
                 await self._node_ready.wait()
                 continue
-
-            # we don't want to cancel nodes on the first error,
-            # as would happen with a task group.
-            # e.g. some nodes might be writing data, and we want that to succeed
-            # even if some other node in this generation fails.
-            # We also want to schedule nodes opportunistically,
-            # as soon as their dependencies are satisfied,
-            # without needing to wait for the entire graph generation to finish
-            # so we queue as many as we can and use futures/callbacks to signal completion
 
             for node_info in ready:
                 node_id, epoch = node_info["value"], node_info["epoch"]
@@ -127,6 +137,12 @@ class AsyncRunner(TubeRunner):
         return self.collect_return()
 
     def _node_complete(self, future: asyncio.Future, node: Node, epoch: int) -> None:
+        self._pending_futures.remove(future)
+        if future.exception():
+            self._logger.debug("Node %s raised exception, re-raising outside of callback")
+            self._exception = future.exception()
+            self._node_ready.set()
+            return
         value = future.result()
         events = self.store.add_value(node.signals, value, node.id, epoch)
         if events is not None:
@@ -134,6 +150,30 @@ class AsyncRunner(TubeRunner):
             self._call_callbacks(all_events)
         self._node_ready.set()
         self._logger.debug("Node %s emitted %s in epoch %s", node.id, value, epoch)
+
+    async def _raise_exception(self) -> None:
+        if not self._exception:
+            raise RuntimeError("Told to raise an exception, but no exception was found!")
+
+        if not self._pending_futures:
+            raise self._exception
+
+        try:
+            async for completed in asyncio.as_completed(
+                self._pending_futures, timeout=self.exception_timeout
+            ):
+                # do nothing with the completed results here, we just want them to complete
+                await completed
+        except TimeoutError:
+            self._logger.warning(
+                "Nodes still running after timeout while waiting to raise exception: %s",
+                self._pending_futures,
+            )
+        except Exception as e:
+            # another node raised an exception, now we're really quitting
+            raise self._exception from e
+        else:
+            raise self._exception
 
     def enable_node(self, node_id: str) -> None:
         self.tube.nodes[node_id].init()

--- a/src/noob/runner/base.py
+++ b/src/noob/runner/base.py
@@ -337,7 +337,6 @@ def call_async_from_sync(
 
     # Closures because this code should never escape the containment tomb of this crime against god
     async def _wrap(call_result: asyncio.Future[_TReturn], fn: Coroutine) -> None:
-        # return await fn
         try:
             result = await fn
             call_result.set_result(result)

--- a/src/noob/runner/base.py
+++ b/src/noob/runner/base.py
@@ -258,7 +258,7 @@ def call_async_from_sync(
 
     We need to make a new thread in **some** way,
     Django's ``asgiref`` has a mindblowingly complicated
-    `async_to_sync <https://github.com/django/asgiref/blob/2b28409ab83b3e4cf6fed9019403b71f8d7d1c51/asgiref/sync.py#L585>`
+    `async_to_sync <https://github.com/django/asgiref/blob/2b28409ab83b3e4cf6fed9019403b71f8d7d1c51/asgiref/sync.py#L585>`_
     function that works **roughly** by creating a new thread
     and then calling :func:`asyncio.run` from *within that*
     (plus about a thousand other things to manage all the edge cases).
@@ -305,8 +305,8 @@ def call_async_from_sync(
     Returns: The result of the called function
 
     References:
-        https://github.com/django/asgiref/blob/2b28409ab83b3e4cf6fed9019403b71f8d7d1c51/asgiref/sync.py#L152
-        https://stackoverflow.com/questions/79663750/call-async-code-inside-sync-code-inside-async-code
+        * https://github.com/django/asgiref/blob/2b28409ab83b3e4cf6fed9019403b71f8d7d1c51/asgiref/sync.py#L152
+        * https://stackoverflow.com/questions/79663750/call-async-code-inside-sync-code-inside-async-code
     """
     if not iscoroutinefunction_partial(fn):
         raise RuntimeError(

--- a/src/noob/runner/base.py
+++ b/src/noob/runner/base.py
@@ -235,6 +235,79 @@ def call_async_from_sync(
     *args: _PProcess.args,
     **kwargs: _PProcess.kwargs,
 ) -> _TReturn:
+    """
+    Call an async function synchronously, either in this thread or a subthread.
+
+    So here's the deal with this nonsense:
+
+    * Calling async from sync is easy when there is no running eventloop in the thread
+    * Calling async from sync is **almost comically hard** when there is a running eventloop.
+
+    We are likely to encounter the second case where, e.g.,
+    some async application calls some other code that uses a :class:`.SyncRunner`
+    to run a tube that has an async node.
+
+    :func:`asyncio.run` and :class:`asyncio.Runner` refuse to run when there is live eventloop,
+    and attempting to use any of the :class:`~asyncio.Task` or :class:`~asyncio.Future`
+    spawning methods from the running eventloop like :meth:`~asyncio.AbstractEventLoop.call_soon`
+    or :func:`asyncio.run_coroutine_threadsafe`
+    and then polling for the result with :meth:`asyncio.Future.result`
+    causes a deadlock between the outer sync thread and the eventloop.
+    The basic problem is that there is no way to wait in the thread (synchronously)
+    that yields the thread to the eventloop (which is what async functions are for).
+
+    We need to make a new thread in **some** way,
+    Django's ``asgiref`` has a mindblowingly complicated
+    `async_to_sync <https://github.com/django/asgiref/blob/2b28409ab83b3e4cf6fed9019403b71f8d7d1c51/asgiref/sync.py#L585>`
+    function that works **roughly** by creating a new thread
+    and then calling :func:`asyncio.run` from *within that*
+    (plus about a thousand other things to manage all the edge cases).
+    That's more than a little bit cursed, because ideally,
+    since the hard case here is where there is already an eventloop in the outer thread,
+    we would be able to just *use that eventloop*.
+    Normally one would just ``await`` the coro directly,
+    which is what :class:`.AsyncRunner` does,
+    but the :class:`.SyncRunner` can't do that because :meth:`.SyncRunner.process` is sync.
+
+    However if one creates a new thread with a new eventloop,
+    that will break any stateful nodes that e.g. have objects like :class:`asyncio.Event`
+    that are bound to the first eventloop.
+
+    Until we can figure out how to reuse the outer eventloop,
+    we do the best we can with a modified version of ``asgiref`` 's approach.
+
+    * Create a :class:`asyncio.Future` to store the eventual result we will return
+      (the "result future")
+    * Wrap the coroutine to call in another coroutine that calls :meth:`~asyncio.Future.set_result`
+      or :meth:`~asyncio.Future.set_exception` on some passed future
+      rather than returning the result directly
+    * Use a :class:`~concurrent.futures.ThreadPoolExecutor` to run the wrapped coroutine
+      in a **new** :class:`asyncio.AbstractEventLoop` in a separate thread,
+      returning a second :class:`~concurrent.futures.Future` (the "completion future")
+    * Add a callback to the completion future that notifies a :class:`~threading.Condition`
+    * Wait in the main thread for the :class:`~threading.Condition` to be notified
+    * Return the result from the result future.
+
+    The reason we don't just directly return the value of the process coroutine
+    in the inner wrapper coroutine
+    and then return the result of the completion future is error handling -
+    Errors raised in the wrapping coroutine have a large amount of noise in the traceback,
+    so instead we use :meth:`~asyncio.Future.set_exception` to propagate the raised error
+    up to the main thread and raise it there.
+
+    Args:
+        fn: The callable that returns a coroutine to run
+        executor (concurrent.futures.ThreadPoolExecutor | None): Provide an already-created
+            thread pool executor. If ``None`` , creates one and shuts it down before returning
+        *args: Passed to ``fn``
+        **kwargs: Passed to ``fn``
+
+    Returns: The result of the called function
+
+    References:
+        https://github.com/django/asgiref/blob/2b28409ab83b3e4cf6fed9019403b71f8d7d1c51/asgiref/sync.py#L152
+        https://stackoverflow.com/questions/79663750/call-async-code-inside-sync-code-inside-async-code
+    """
     if not iscoroutinefunction_partial(fn):
         raise RuntimeError(
             "Called a synchronous function from call_async_from_sync, "
@@ -254,7 +327,9 @@ def call_async_from_sync(
         else:
             raise e
 
+    created = False
     if executor is None:
+        created = True
         executor = ThreadPoolExecutor(1)
 
     result_future: asyncio.Future[_TReturn] = asyncio.Future()
@@ -262,6 +337,7 @@ def call_async_from_sync(
 
     # Closures because this code should never escape the containment tomb of this crime against god
     async def _wrap(call_result: asyncio.Future[_TReturn], fn: Coroutine) -> None:
+        # return await fn
         try:
             result = await fn
             call_result.set_result(result)
@@ -277,4 +353,9 @@ def call_async_from_sync(
 
     with work_ready:
         work_ready.wait()
-    return result_future.result()
+    try:
+        res = result_future.result()
+        return res
+    finally:
+        if created:
+            executor.shutdown(wait=False)

--- a/src/noob/runner/zmq.py
+++ b/src/noob/runner/zmq.py
@@ -67,10 +67,11 @@ from noob.network.message import (
     StopMsg,
 )
 from noob.node import Node, NodeSpecification, Return
-from noob.runner.base import TubeRunner
+from noob.runner.base import TubeRunner, call_async_from_sync
 from noob.scheduler import Scheduler
 from noob.store import EventStore
 from noob.types import NodeID, ReturnNodeType
+from noob.utils import iscoroutinefunction_partial
 
 if TYPE_CHECKING:
     pass
@@ -344,11 +345,17 @@ class NodeRunner(EventloopMixin):
             runner._freerun.clear()
             runner._process_one.clear()
 
+            is_async = iscoroutinefunction_partial(runner._node.process)
+
             for args, kwargs, epoch in runner.await_inputs():
                 runner.logger.debug(
                     "Running with args: %s, kwargs: %s, epoch: %s", args, kwargs, epoch
                 )
-                value = runner._node.process(*args, **kwargs)
+                if is_async:
+                    # mypy fails here because it can't propagate the type guard above
+                    value = call_async_from_sync(runner._node.process, *args, **kwargs)  # type: ignore[arg-type]
+                else:
+                    value = runner._node.process(*args, **kwargs)
                 events = runner.store.add_value(runner._node.signals, value, runner._node.id, epoch)
                 runner.scheduler.add_epoch()
 

--- a/src/noob/runner/zmq.py
+++ b/src/noob/runner/zmq.py
@@ -132,8 +132,8 @@ class CommandNode(EventloopMixin):
 
     def start(self) -> None:
         self.logger.debug("Starting command runner")
-        self._init_sockets()
         self.start_loop()
+        self._init_sockets()
         self.logger.debug("Command runner started")
 
     def stop(self) -> None:
@@ -449,8 +449,8 @@ class NodeRunner(EventloopMixin):
             self._dealer.send_multipart([msg.to_bytes()])
 
     def start_sockets(self) -> None:
-        self._init_sockets()
         self.start_loop()
+        self._init_sockets()
 
     def init_node(self) -> None:
         self._node = Node.from_specification(self.spec, self.input_collection)

--- a/src/noob/testing/__init__.py
+++ b/src/noob/testing/__init__.py
@@ -12,6 +12,7 @@ from noob.testing.nodes import (
     Volume,
     VolumeProcess,
     array_add_to_left,
+    async_error,
     concat,
     count_source,
     dictify,
@@ -32,6 +33,7 @@ from noob.testing.nodes import (
 )
 
 __all__ = [
+    "async_error",
     "concat",
     "count_source",
     "dictify",

--- a/src/noob/testing/nodes.py
+++ b/src/noob/testing/nodes.py
@@ -186,3 +186,8 @@ class NumberToLetterCls:
         sleep_for = random.random() / 10
         await asyncio.sleep(sleep_for)
         return string.ascii_lowercase[(number + self.offset) % len(string.ascii_lowercase)]
+
+
+async def async_error(value: Any) -> None:
+    """Just raise an error!"""
+    raise ValueError("This is the error that should be raised")

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -1,4 +1,3 @@
-
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -1,11 +1,9 @@
-import asyncio
-from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
 from noob import Tube
-from noob.runner.base import TubeRunner, call_async_from_sync
+from noob.runner.base import TubeRunner
 from noob.runner.zmq import ZMQRunner
 
 
@@ -32,22 +30,3 @@ def test_long_add(benchmark: BenchmarkFixture, runner: TubeRunner) -> None:
     and there's lots of concurrency possibilities
     """
     benchmark(lambda: runner.process())
-
-
-@pytest.mark.parametrize("make_executor", [True, False])
-@pytest.mark.asyncio
-async def test_on_demand_async_executor(benchmark: BenchmarkFixture, make_executor: bool) -> None:
-    """
-    Just checking how much overhead there is in creating a new executor.
-
-    Test function is itself a coroutine because we only use executor
-    when calling async from sync within async lol.
-    """
-
-    async def _wait() -> None:
-        # just await anything, want to actually engage the eventloop but not take any static time
-        await asyncio.sleep(0)
-
-    exc = ThreadPoolExecutor(1) if make_executor else None
-
-    benchmark(lambda: call_async_from_sync(_wait, executor=exc))

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -1,8 +1,11 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
 from noob import Tube
-from noob.runner.base import TubeRunner
+from noob.runner.base import TubeRunner, call_async_from_sync
 from noob.runner.zmq import ZMQRunner
 
 
@@ -29,3 +32,22 @@ def test_long_add(benchmark: BenchmarkFixture, runner: TubeRunner) -> None:
     and there's lots of concurrency possibilities
     """
     benchmark(lambda: runner.process())
+
+
+@pytest.mark.parametrize("make_executor", [True, False])
+@pytest.mark.asyncio
+async def test_on_demand_async_executor(benchmark: BenchmarkFixture, make_executor: bool) -> None:
+    """
+    Just checking how much overhead there is in creating a new executor.
+
+    Test function is itself a coroutine because we only use executor
+    when calling async from sync within async lol.
+    """
+
+    async def _wait() -> None:
+        # just await anything, want to actually engage the eventloop but not take any static time
+        await asyncio.sleep(0)
+
+    exc = ThreadPoolExecutor(1) if make_executor else None
+
+    benchmark(lambda: call_async_from_sync(_wait, executor=exc))

--- a/tests/data/special/async_error.yaml
+++ b/tests/data/special/async_error.yaml
@@ -1,0 +1,13 @@
+noob_id: testing-async-error
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.0.1.dev5+g4d26757.d20250320
+nodes:
+  a:
+    type: noob.testing.count_source
+  b:
+    type: noob.testing.async_error
+    depends:
+    - value: a.index
+  c:
+    type: return
+    depends: b.value

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -10,7 +10,7 @@ from .config import (
 )
 from .meta import monkeypatch_session
 from .paths import CONFIG_DIR, DATA_DIR, PIPELINE_DIR
-from .runner import runner, runner_cls
+from .runner import all_runner_cls, all_runners, runner, sync_runner_cls
 from .tubes import all_tubes, loaded_tube, no_input_tubes
 
 __all__ = [
@@ -18,11 +18,13 @@ __all__ = [
     "DATA_DIR",
     "PIPELINE_DIR",
     "all_tubes",
+    "all_runners",
+    "all_runner_cls",
     "loaded_tube",
     "monkeypatch_session",
     "no_input_tubes",
     "runner",
-    "runner_cls",
+    "sync_runner_cls",
     "set_config",
     "set_dotenv",
     "set_env",

--- a/tests/fixtures/runner.py
+++ b/tests/fixtures/runner.py
@@ -1,8 +1,10 @@
 import pytest
+import pytest_asyncio
 
 from noob import Tube
-from noob.runner import SynchronousRunner, TubeRunner
+from noob.runner import AsyncRunner, SynchronousRunner, TubeRunner
 from noob.runner.zmq import ZMQRunner
+from noob.utils import iscoroutinefunction_partial
 
 
 @pytest.fixture(
@@ -11,13 +13,39 @@ from noob.runner.zmq import ZMQRunner
         pytest.param(ZMQRunner, marks=[pytest.mark.zmq_runner]),
     ]
 )
-def runner_cls(request: pytest.FixtureRequest) -> type[TubeRunner]:
+def sync_runner_cls(request: pytest.FixtureRequest) -> type[TubeRunner]:
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(SynchronousRunner, marks=[pytest.mark.sync_runner]),
+        pytest.param(ZMQRunner, marks=[pytest.mark.zmq_runner]),
+        pytest.param(AsyncRunner, marks=[pytest.mark.async_runner]),
+    ]
+)
+def all_runner_cls(request: pytest.FixtureRequest) -> type[TubeRunner]:
     return request.param
 
 
 @pytest.fixture
-def runner(loaded_tube: Tube, runner_cls: type[TubeRunner]) -> TubeRunner:
-    r = runner_cls(loaded_tube)
+def runner(loaded_tube: Tube, sync_runner_cls: type[TubeRunner]) -> TubeRunner:
+    r = sync_runner_cls(loaded_tube)
     r.init()
     yield r
     r.deinit()
+
+
+@pytest_asyncio.fixture
+async def all_runners(loaded_tube: Tube, all_runner_cls: type[TubeRunner]) -> TubeRunner:
+    """all runners including async runners"""
+    r = all_runner_cls(loaded_tube)
+    if iscoroutinefunction_partial(r.init):
+        await r.init()
+    else:
+        r.init()
+    yield r
+    if iscoroutinefunction_partial(r.deinit):
+        await r.deinit()
+    else:
+        r.deinit()

--- a/tests/test_pipelines/test_async.py
+++ b/tests/test_pipelines/test_async.py
@@ -1,0 +1,49 @@
+import asyncio
+import string
+
+import numpy as np
+import pytest
+
+from noob import SynchronousRunner, Tube
+from noob.runner import TubeRunner
+from noob.utils import iscoroutinefunction_partial
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize("loaded_tube", ["testing-async"], indirect=True)
+def test_async_in_sync(loaded_tube: Tube):
+    """
+    The sync runner should be able to run async nodes when there is no outer eventloop
+    """
+    with pytest.raises(RuntimeError):
+        # there shouldn't be any eventloop running!
+        asyncio.get_running_loop()
+
+    runner = SynchronousRunner(loaded_tube)
+    with runner:
+        for i in range(10):
+            res = runner.process()
+            assert res == (
+                string.ascii_lowercase[i],
+                string.ascii_lowercase[i + 1],
+                string.ascii_lowercase[i + 2],
+            )
+
+
+@pytest.mark.parametrize("loaded_tube", ["testing-async"], indirect=True)
+@pytest.mark.asyncio
+async def test_async_in_async(loaded_tube: Tube, runner: TubeRunner) -> None:
+    """
+    All runners should be able to handle async nodes when run in an outer eventloop
+    """
+    for i in range(10):
+        if iscoroutinefunction_partial(runner.process):
+            res = await runner.process()
+        else:
+            res = runner.process()
+        assert res == (
+            string.ascii_lowercase[i],
+            string.ascii_lowercase[i + 1],
+            string.ascii_lowercase[i + 2],
+        )

--- a/tests/test_pipelines/test_basic.py
+++ b/tests/test_pipelines/test_basic.py
@@ -96,12 +96,12 @@ def test_map():
 
 
 @pytest.mark.parametrize("loaded_tube", ["testing-multi-signal"], indirect=True)
-def test_multi_signal(loaded_tube: Tube, runner_cls: type[TubeRunner]):
+def test_multi_signal(loaded_tube: Tube, sync_runner_cls):
     """
     Nodes that emit multiple signals can have each used independently
     """
     tube = Tube.from_specification("testing-multi-signal")
-    runner = runner_cls(tube)
+    runner = sync_runner_cls(tube)
 
     for value in runner.iter(n=5):
         assert isinstance(value, dict)

--- a/tests/test_runners/test_async.py
+++ b/tests/test_runners/test_async.py
@@ -5,6 +5,8 @@ import pytest
 from noob import Tube
 from noob.runner import AsyncRunner
 
+pytestmark = [pytest.mark.asyncio, pytest.mark.async_runner]
+
 
 @pytest.mark.asyncio
 async def test_async_base():


### PR DESCRIPTION
Fix: #42 

Punting docs to #120 

OK so this was was harder than i thought. The strategy for calling async from sync is mostly described in the docstring, but i'll reproduce that here:

> Call an async function synchronously, either in this thread or a subthread.
> 
> So here's the deal with this nonsense:
> 
> * Calling async from sync is easy when there is no running eventloop in the thread
> * Calling async from sync is **almost comically hard** when there is a running eventloop.
> 
> We are likely to encounter the second case where, e.g.,
> some async application calls some other code that uses a :class:`.SyncRunner`
> to run a tube that has an async node.
> 
> :func:`asyncio.run` and :class:`asyncio.Runner` refuse to run when there is live eventloop,
> and attempting to use any of the :class:`~asyncio.Task` or :class:`~asyncio.Future`
> spawning methods from the running eventloop like :meth:`~asyncio.AbstractEventLoop.call_soon`
> or :func:`asyncio.run_coroutine_threadsafe`
> and then polling for the result with :meth:`asyncio.Future.result`
> causes a deadlock between the outer sync thread and the eventloop.
> The basic problem is that there is no way to wait in the thread (synchronously)
> that yields the thread to the eventloop (which is what async functions are for).
> 
> We need to make a new thread in **some** way,
> Django's ``asgiref`` has a mindblowingly complicated
> `async_to_sync <https://github.com/django/asgiref/blob/2b28409ab83b3e4cf6fed9019403b71f8d7d1c51/asgiref/sync.py#L585>`
> function that works **roughly** by creating a new thread
> and then calling :func:`asyncio.run` from *within that*
> (plus about a thousand other things to manage all the edge cases).
> That's more than a little bit cursed, because ideally,
> since the hard case here is where there is already an eventloop in the outer thread,
> we would be able to just *use that eventloop*.
> Normally one would just ``await`` the coro directly,
> which is what :class:`.AsyncRunner` does,
> but the :class:`.SyncRunner` can't do that because :meth:`.SyncRunner.process` is sync.
> 
> However if one creates a new thread with a new eventloop,
> that will break any stateful nodes that e.g. have objects like :class:`asyncio.Event`
> that are bound to the first eventloop.
> 
> Until we can figure out how to reuse the outer eventloop,
> we do the best we can with a modified version of ``asgiref`` 's approach.
> 
> * Create a :class:`asyncio.Future` to store the eventual result we will return
>   (the "result future")
> * Wrap the coroutine to call in another coroutine that calls :meth:`~asyncio.Future.set_result`
>   or :meth:`~asyncio.Future.set_exception` on some passed future
>   rather than returning the result directly
> * Use a :class:`~concurrent.futures.ThreadPoolExecutor` to run the wrapped coroutine
>   in a **new** :class:`asyncio.AbstractEventLoop` in a separate thread,
>   returning a second :class:`~concurrent.futures.Future` (the "completion future")
> * Add a callback to the completion future that notifies a :class:`~threading.Condition`
> * Wait in the main thread for the :class:`~threading.Condition` to be notified
> * Return the result from the result future.
> 
> The reason we don't just directly return the value of the process coroutine
> in the inner wrapper coroutine
> and then return the result of the completion future is error handling -
> Errors raised in the wrapping coroutine have a large amount of noise in the traceback,
> so instead we use :meth:`~asyncio.Future.set_exception` to propagate the raised error
> up to the main thread and raise it there.

for reference: https://github.com/django/asgiref/blob/2b28409ab83b3e4cf6fed9019403b71f8d7d1c51/asgiref/sync.py#L585

In testing, discovered some other problems:
- Async runner was not handling exceptions raised within nodes, as they were raised in the `node_complete` callback, which didn't kill the `process` method like i thought it would (idk why i thought it would). so as a result the asyncrunner would just wait indefinitely for the node ready event to be set. Added explicit error handling
- ZMQRunner (specifically the EventLoopMixin part) could not run when there was already an eventloop running outside, as it would try and use that loop instead of creating one within the thread that it spawns. so forced it to use the loop from within the thread, start that before creating the sockets, and all is well.

But now! 
- SyncRunner can run async nodes
- ZMQRunner can run async nodes

Benchmarking the difference between spawning a thread on demand and using a premade ThreadPoolExecutor:
- on demand: 413us (best), 3212 iters
- premade: 322us (best), 4088 iters

so 1.3 times as long at worst and on average. not *too* terrible, but i'm not going to handle setting up and tearing down the thread pool executor until i do #23 so i can do it cleanly.


<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--119.org.readthedocs.build/en/119/

<!-- readthedocs-preview noob end -->