### PR TITLE
inputs in zmq runner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ markers = [
     "async_runner: uses the async runner",
     "sync_runner: uses the sync runner",
     "zmq_runner: uses the zmq runner",
+    "input: tube and process inputs",
 ]
 
 [tool.black]

--- a/src/noob/network/message.py
+++ b/src/noob/network/message.py
@@ -92,6 +92,11 @@ class ErrorValue(TypedDict):
     traceback: str
 
 
+class ProcessValue(TypedDict):
+    epoch: int
+    input: dict | None
+
+
 class AnnounceMsg(Message):
     """Command node 'announces' identities of other peers and the events they emit"""
 
@@ -110,7 +115,8 @@ class ProcessMsg(Message):
     """Process a single iteration of the graph"""
 
     type_: Literal[MessageType.process] = Field(MessageType.process, alias="type")
-    value: None = None
+    value: ProcessValue
+    """Any process-scoped input passed to the `process` call"""
 
 
 class StartMsg(Message):

--- a/tests/test_pipelines/test_input.py
+++ b/tests/test_pipelines/test_input.py
@@ -7,20 +7,20 @@ from noob.runner.base import TubeRunner
 pytestmark = pytest.mark.input
 
 
-def test_tube_input_params(runner_cls: type[TubeRunner]):
+def test_tube_input_params(sync_runner_cls: type[TubeRunner]):
     """tube-scoped input can be used as params"""
     tube = Tube.from_specification("testing-input-tube-params", input={"start": 7})
-    runner = runner_cls(tube)
+    runner = sync_runner_cls(tube)
     with runner:
         outputs = [runner.process() for _ in range(5)]
         assert len(outputs) == 5
         assert outputs == [7, 8, 9, 10, 11]
 
 
-def test_tube_input_depends(runner_cls: type[TubeRunner]):
+def test_tube_input_depends(sync_runner_cls: type[TubeRunner]):
     """tube-scoped input can be used as depends"""
     tube = Tube.from_specification("testing-input-tube-depends", input={"multiply_right": 7})
-    runner = runner_cls(tube)
+    runner = sync_runner_cls(tube)
     with runner:
         outputs = [runner.process() for _ in range(5)]
         assert len(outputs) == 5
@@ -72,7 +72,7 @@ def test_process_input_missing(loaded_tube, runner):
     assert runner.process(multiply_right=10) == 0
 
 
-def test_input_integration(runner_cls):
+def test_input_integration(sync_runner_cls):
     """
     All the different forms of input can be used together
     """
@@ -83,7 +83,7 @@ def test_input_integration(runner_cls):
         "testing-input-mixed", input={"start": start, "multiply_tube": multiply_tube}
     )
 
-    runner = runner_cls(tube)
+    runner = sync_runner_cls(tube)
     with runner:
         for i in range(5):
             this_process = multiply_process * 2 * (i + 1)

--- a/tests/test_pipelines/test_input.py
+++ b/tests/test_pipelines/test_input.py
@@ -2,26 +2,29 @@ import pytest
 
 from noob import SynchronousRunner, Tube
 from noob.exceptions import ExtraInputWarning, InputMissingError
+from noob.runner.base import TubeRunner
+
+pytestmark = pytest.mark.input
 
 
-def test_tube_input_params():
+def test_tube_input_params(runner_cls: type[TubeRunner]):
     """tube-scoped input can be used as params"""
     tube = Tube.from_specification("testing-input-tube-params", input={"start": 7})
-    runner = SynchronousRunner(tube)
+    runner = runner_cls(tube)
+    with runner:
+        outputs = [runner.process() for _ in range(5)]
+        assert len(outputs) == 5
+        assert outputs == [7, 8, 9, 10, 11]
 
-    outputs = runner.run(n=5)
-    assert len(outputs) == 5
-    assert outputs == [7, 8, 9, 10, 11]
 
-
-def test_tube_input_depends():
+def test_tube_input_depends(runner_cls: type[TubeRunner]):
     """tube-scoped input can be used as depends"""
     tube = Tube.from_specification("testing-input-tube-depends", input={"multiply_right": 7})
-    runner = SynchronousRunner(tube)
-
-    outputs = runner.run(n=5)
-    assert len(outputs) == 5
-    assert outputs == [i * 7 for i in range(5)]
+    runner = runner_cls(tube)
+    with runner:
+        outputs = [runner.process() for _ in range(5)]
+        assert len(outputs) == 5
+        assert outputs == [i * 7 for i in range(5)]
 
 
 def test_process_input_params():
@@ -33,11 +36,9 @@ def test_process_input_params():
         Tube.from_specification("testing-input-process-params", input={"start": 7})
 
 
-def test_process_input_depends():
+@pytest.mark.parametrize("loaded_tube", ["testing-input-process-depends"], indirect=True)
+def test_process_input_depends(loaded_tube, runner):
     """process-scoped input can be used as depends"""
-    tube = Tube.from_specification("testing-input-process-depends")
-    runner = SynchronousRunner(tube)
-
     for left, right in zip(range(5), range(5, 10)):
         assert runner.process(multiply_right=right) == left * right
 
@@ -55,12 +56,9 @@ def test_tube_input_missing(tube):
         Tube.from_specification(tube, input={"irrelevant": 7})
 
 
-@pytest.mark.parametrize("tube", ("testing-input-process-depends",))
-def test_process_input_missing(tube):
+@pytest.mark.parametrize("loaded_tube", ("testing-input-process-depends",), indirect=True)
+def test_process_input_missing(loaded_tube, runner):
     """Input scoped as process input raises an error when missing"""
-    tube = Tube.from_specification("testing-input-process-depends")
-    runner = SynchronousRunner(tube)
-
     with pytest.raises(InputMissingError):
         runner.process()
 
@@ -74,7 +72,7 @@ def test_process_input_missing(tube):
     assert runner.process(multiply_right=10) == 0
 
 
-def test_input_integration():
+def test_input_integration(runner_cls):
     """
     All the different forms of input can be used together
     """
@@ -85,9 +83,9 @@ def test_input_integration():
         "testing-input-mixed", input={"start": start, "multiply_tube": multiply_tube}
     )
 
-    runner = SynchronousRunner(tube)
-
-    for i in range(5):
-        this_process = multiply_process * 2 * (i + 1)
-        expected = (start + i) * multiply_tube * this_process
-        assert runner.process(multiply_process=this_process) == expected
+    runner = runner_cls(tube)
+    with runner:
+        for i in range(5):
+            this_process = multiply_process * 2 * (i + 1)
+            expected = (start + i) * multiply_tube * this_process
+            assert runner.process(multiply_process=this_process) == expected


### PR DESCRIPTION
Fix: #70 

i think pretty self explanatory?

We give tube-scoped inputs to the node classes when creating them, then we give process-scoped inputs in the `ProcessMessage`. Since we can have potentially multiple epochs in queue and also the process calls can come out of order, we don't use the input collection like we do in the sync runner, but instead use the event store. this all ends up working pretty much perfectly between the eventstore and scheduler - `inputs` are dependencies in the scheduler that we mark done when we get them, then we get their values from the eventstore like we would any other events...

then i just made the tests parameterized over both runners, and since those are the same tests we have for input generally, zmq is at feature parity for inputs.

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--122.org.readthedocs.build/en/122/

<!-- readthedocs-preview noob end -->