### PR TITLE
Raise when trying to use `run` or `iter` on tubes with process-scoped inputs

### DIFF
--- a/src/noob/runner/base.py
+++ b/src/noob/runner/base.py
@@ -16,6 +16,8 @@ from typing import Any, ParamSpec, Self, TypeVar
 
 from noob import Tube, init_logger
 from noob.event import Event, MetaEvent
+from noob.exceptions import InputMissingError
+from noob.input import InputScope
 from noob.node import Node
 from noob.store import EventStore
 from noob.types import PythonIdentifier, ReturnNodeType, RunnerContext
@@ -94,6 +96,14 @@ class TubeRunner(ABC):
         (e.g. multiple times in the case of any ``gather`` s
         that change the cardinality of the graph.)
         """
+        try:
+            _ = self.tube.input_collection.validate_input(InputScope.process, {})
+        except InputMissingError as e:
+            raise InputMissingError(
+                "Can't use the `iter` method with tubes with process-scoped input "
+                "that was not provided when instantiating the tube! "
+                "Use `process()` directly, providing required inputs to each call."
+            ) from e
 
         self.init()
         current_iter = 0
@@ -113,6 +123,14 @@ class TubeRunner(ABC):
             self.deinit()
 
     def run(self, n: int | None = None) -> None | list[ReturnNodeType]:
+        try:
+            _ = self.tube.input_collection.validate_input(InputScope.process, {})
+        except InputMissingError as e:
+            raise InputMissingError(
+                "Can't use the `run` method with tubes with process-scoped input "
+                "that was not provided when instantiating the tube! "
+                "Use `process()` directly, providing required inputs to each call."
+            ) from e
         outputs = []
         current_iter = 0
         if not self.running:

--- a/tests/test_pipelines/test_input.py
+++ b/tests/test_pipelines/test_input.py
@@ -89,3 +89,24 @@ def test_input_integration(sync_runner_cls):
             this_process = multiply_process * 2 * (i + 1)
             expected = (start + i) * multiply_tube * this_process
             assert runner.process(multiply_process=this_process) == expected
+
+
+@pytest.mark.parametrize("loaded_tube", ["testing-input-process-depends"], indirect=True)
+@pytest.mark.asyncio
+async def test_no_run_with_process_input(loaded_tube, all_runners):
+    """
+    Trying to use `run` with a tube with process-scoped inputs should fail!
+    """
+    with pytest.raises(InputMissingError):
+        all_runners.run(n=5)
+
+
+@pytest.mark.parametrize("loaded_tube", ["testing-input-process-depends"], indirect=True)
+@pytest.mark.asyncio
+async def test_no_iter_with_process_input(loaded_tube, all_runners):
+    """
+    Trying to use `run` with a tube with process-scoped inputs should fail!
+    """
+    with pytest.raises(InputMissingError):
+        for _ in all_runners.iter(n=5):
+            pass


### PR DESCRIPTION
Fix: #124

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--125.org.readthedocs.build/en/125/

<!-- readthedocs-preview noob end -->