### PR TITLE
add description field to specs

### DIFF
--- a/src/noob/asset.py
+++ b/src/noob/asset.py
@@ -64,6 +64,8 @@ class AssetSpecification(BaseModel):
     The node signal that this asset specification depends on will be the version of the asset
     stored and used in the next processing epoch.
     """
+    description: str | None = None
+    """An optional description of the asset"""
 
     @model_validator(mode="after")
     def validate_depends(self) -> Self:

--- a/src/noob/input.py
+++ b/src/noob/input.py
@@ -39,6 +39,8 @@ class InputSpecification(BaseModel):
     id: PythonIdentifier
     type_: AbsoluteIdentifier = Field(..., alias="type")
     scope: InputScope = InputScope.tube
+    description: str | None = None
+    """An optional description of the input value"""
 
 
 class InputCollection(BaseModel):

--- a/src/noob/node/spec.py
+++ b/src/noob/node/spec.py
@@ -119,6 +119,8 @@ class NodeSpecification(BaseModel):
     explicitly set statefulness on a node, overriding its default.
     If ``None`` , use the default set on the node class.
     """
+    description: str | None = None
+    """An optional description of the node"""
 
     @field_validator("depends", mode="after")
     @classmethod

--- a/src/noob/tube.py
+++ b/src/noob/tube.py
@@ -45,6 +45,9 @@ class TubeSpecification(ConfigYAMLMixin):
     nodes: dict[PythonIdentifier, NodeSpecification] = Field(default_factory=dict)
     """The nodes that this tube configures"""
 
+    description: str | None = None
+    """An optional description of the tube"""
+
     @field_validator("nodes", "assets", "input", mode="before")
     @classmethod
     def fill_node_ids(cls, value: dict[str, dict]) -> dict[str, dict]:


### PR DESCRIPTION
we've talked about this before, just want to add an optional `description` field to be able to annotate yaml specs

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--131.org.readthedocs.build/en/131/

<!-- readthedocs-preview noob end -->