### PR TITLE
emit recursive tube return values as events when they are a dictlike …

### DIFF
--- a/packages/noob/src/noob/node/tube.py
+++ b/packages/noob/src/noob/node/tube.py
@@ -1,9 +1,12 @@
+import uuid
 import warnings
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Union
 
+from noob.event import Event
 from noob.exceptions import ExtraInputWarning
 from noob.node.base import Node, Slot
-from noob.types import ConfigSource, RunnerContext
+from noob.types import ConfigSource, Epoch, RunnerContext
 
 if TYPE_CHECKING:
     from noob.runner import TubeRunner
@@ -44,14 +47,29 @@ class TubeNode(Node):
         if self._runner is not None:
             self._runner.deinit()
 
-    def process(self, **kwargs: Any) -> Any:
+    def process(self, epoch: Epoch, **kwargs: Any) -> Any:
         if self._runner is None:
             raise RuntimeError(
                 "TubeNode must be initialized within a Runner "
                 "to receive the outer runner's context. "
                 "It doesn't make sense to run a TubeNode on its own."
             )
-        return self._runner.process(**kwargs)
+        res = self._runner.process(**kwargs)
+        if isinstance(res, dict):
+            now = datetime.now(UTC)
+            return [
+                Event(
+                    id=uuid.uuid4().int,
+                    timestamp=now,
+                    node_id=self.id,
+                    signal=key,
+                    epoch=epoch,
+                    value=value,
+                )
+                for key, value in res.items()
+            ]
+        else:
+            return res
 
     def _collect_slots(self) -> dict[str, Slot]:
         from noob.input import InputScope

--- a/packages/noob/tests/data/pipelines/recursive/recursive_signals.yaml
+++ b/packages/noob/tests/data/pipelines/recursive/recursive_signals.yaml
@@ -1,0 +1,24 @@
+noob_id: testing-recursive-signals
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.0.1
+description: |
+  A parent tube can have nodes that depend on the signals emitted by the return node in the child tube
+
+nodes:
+  child:
+    type: tube
+    params:
+      tube: testing-branch
+  multiply:
+    type: noob.testing.multiply
+    depends:
+      - left: child.multiply
+  divide:
+    type: noob.testing.divide
+    depends:
+      - numerator: child.divide
+  return:
+    type: return
+    depends:
+      - multiply: multiply.value
+      - divide: divide.ratio

--- a/packages/noob/tests/test_pipelines/test_recursive.py
+++ b/packages/noob/tests/test_pipelines/test_recursive.py
@@ -23,3 +23,16 @@ def test_recursive_pipeline():
         assert res["index"] == parent_start + i
         assert res["child"] == expected_child
         assert res["parent"] == expected_parent
+
+
+def test_recursive_signals():
+    """
+    A parent tube can depend on the return values child tube when
+    it has a dict-like return node
+    """
+    tube = Tube.from_specification("testing-recursive-signals")
+    runner = SynchronousRunner(tube)
+    for i in range(5):
+        res = runner.process()
+        assert res["multiply"] == i * 2 * 2
+        assert res["divide"] == i / 5 / 5


### PR DESCRIPTION
fix: #163 

when the return node of a nested tube returns a dictlike value, we should be able to depend on it in the parent tube.

When a node emits a scalar or list of return values, we return them as a "value" signal, like normal, since there wouldn't be any other way to refer to them anyway.

(we should *not* allow the parent tube to listen to arbitrary signals from the child tube to avoid breaking containment and making recursion extremely error prone and costly).



<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--169.org.readthedocs.build/en/169/

<!-- readthedocs-preview noob end -->