### PR TITLE
allow asset dependencies after gather

### DIFF
--- a/packages/noob/src/noob/network/message.py
+++ b/packages/noob/src/noob/network/message.py
@@ -34,6 +34,7 @@ class MessageType(StrEnum):
     stop = "stop"
     event = "event"
     error = "error"
+    epoch_ended = "epoch_ended"
 
 
 class NodeStatus(StrEnum):
@@ -175,6 +176,16 @@ class ErrorMsg(Message):
         return err
 
 
+class EpochEndedMsg(Message):
+    """
+    Command node is signaling that an epoch has been completed to all nodes,
+    which don't have a complete picture of the tube's state.
+    """
+
+    type_: Literal[MessageType.epoch_ended] = Field(MessageType.epoch_ended, alias="type")
+    value: Epoch
+
+
 class EventMsg(Message):
     type_: Literal[MessageType.event] = Field(MessageType.event, alias="type")
     value: list[EventUnion]
@@ -201,6 +212,7 @@ MessageUnion = A[
     | A[StopMsg, Tag("stop")]
     | A[EventMsg, Tag("event")]
     | A[ErrorMsg, Tag("error")]
+    | A[EpochEndedMsg, Tag("epoch_ended")]
     | A[Message, Tag("any")],
     Discriminator(_type_discriminator),
 ]

--- a/packages/noob/src/noob/runner/base.py
+++ b/packages/noob/src/noob/runner/base.py
@@ -316,7 +316,7 @@ class TubeRunner(ABC):
             inputs |= {node.injections["epoch"]: epoch}
 
         self.tube.state.init(AssetScope.node)
-        state_inputs = self.tube.state.collect(edges, epoch)
+        state_inputs = self.tube.state.collect(edges)
         inputs |= state_inputs if state_inputs else inputs
 
         event_inputs = self.store.collect(edges, epoch, eventmap=node.injections.get("events"))

--- a/packages/noob/src/noob/runner/zmq/command.py
+++ b/packages/noob/src/noob/runner/zmq/command.py
@@ -12,6 +12,7 @@ from noob.network.message import (
     AnnounceMsg,
     AnnounceValue,
     DeinitMsg,
+    EpochEndedMsg,
     IdentifyMsg,
     IdentifyValue,
     Message,
@@ -176,6 +177,11 @@ class CommandNode(EventloopMixin):
             ],
         )
         self.logger.debug("Sent process message")
+
+    async def epoch_ended(self, epoch: Epoch) -> None:
+        await self.sockets["outbox"].send_multipart(
+            [b"epoch_ended", EpochEndedMsg(node_id="command", value=epoch).to_bytes()]
+        )
 
     def await_ready(self, node_ids: list[NodeID], timeout: float = 10) -> None:
         """

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -27,6 +27,7 @@ from noob.network.loop import EventloopMixin
 from noob.network.message import (
     AnnounceMsg,
     DeinitMsg,
+    EpochEndedMsg,
     ErrorMsg,
     ErrorValue,
     EventMsg,
@@ -384,7 +385,7 @@ class NodeRunner(EventloopMixin):
 
                 self.state.init(AssetScope.node, self._node.edges)
                 self.state.init(AssetScope.process, self._node.edges)
-                assets = self.state.collect(self._node.edges, ready["epoch"])
+                assets = self.state.collect(self._node.edges)
                 inputs |= assets if assets else {}
 
                 if self._node.injections.get("epoch"):
@@ -573,6 +574,8 @@ class NodeRunner(EventloopMixin):
             await self.on_deinit(message)
         elif message.type_ == MessageType.ping:
             await self.identify()
+        elif message.type_ == MessageType.epoch_ended:
+            await self.on_epoch_ended(message)
         else:
             # log but don't throw - other nodes shouldn't be able to crash us
             self.logger.error(f"{message.type_} not implemented!")
@@ -717,6 +720,22 @@ class NodeRunner(EventloopMixin):
             ),
         )
         await self.sockets["dealer"].send_multipart([msg.to_bytes()])
+
+    async def on_epoch_ended(self, msg: EpochEndedMsg) -> None:
+        """
+        Command node has told us that an epoch has ended.
+        Under most conditions, we don't need to be told this explicitly,
+        but when we are a node that stores an asset from a later node,
+        we need to mark the asset as done manually.
+        """
+        if not self.scheduler.epoch_completed(msg.value):
+            with self._ready_condition:
+                self.scheduler.end_epoch(msg.value)
+                self._ready_condition.notify_all()
+        if self.state.dependencies and not self._assets_done(msg.value + 1):
+            with contextlib.suppress(AlreadyDoneError), self._ready_condition:
+                self.scheduler.done(epoch=msg.value + 1, node_id="assets")
+                self._ready_condition.notify_all()
 
     async def await_node(self, epoch: Epoch | None = None) -> list[MetaEvent]:
         """

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -729,10 +729,15 @@ class NodeRunner(EventloopMixin):
         but when we are a node that stores an asset from a later node,
         we need to mark the asset as done manually.
         """
-        if not self.scheduler.epoch_completed(msg.value):
-            async with self._ready_condition:
-                self.scheduler.end_epoch(msg.value)
-                self._ready_condition.notify_all()
+        # one might suspect that we might want to do something like this here
+        # if not self.scheduler.epoch_completed(msg.value):
+        #     async with self._ready_condition:
+        #         self.scheduler.end_epoch(msg.value)
+        #         self._ready_condition.notify_all()
+        # and that suspicion might be correct, but we also might get messages out of order
+        # and get an EpochCompletedError if we get an event from that epoch after the EpochCompleted
+        # message. so until this is a problem in some real tube, we let events drive scheduling.
+
         if self.state.dependencies and not self._assets_done(msg.value + 1):
             with contextlib.suppress(AlreadyDoneError):
                 async with self._ready_condition:

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -21,7 +21,7 @@ from noob import init_logger
 from noob.asset import AssetScope, AssetSpecification
 from noob.config import config
 from noob.event import Event, MetaEvent
-from noob.exceptions import AlreadyDoneError
+from noob.exceptions import AlreadyDoneError, EpochCompletedError
 from noob.input import InputCollection
 from noob.network.loop import EventloopMixin
 from noob.network.message import (
@@ -628,7 +628,10 @@ class NodeRunner(EventloopMixin):
             self.store.add(event)
 
         async with self._ready_condition:
-            self.scheduler.update(to_update)
+            # we might have already been told the epoch was completed,
+            # so this information is redundant.
+            with contextlib.suppress(EpochCompletedError):
+                self.scheduler.update(to_update)
             self._handle_assets(msg)
             self._ready_condition.notify_all()
 
@@ -729,14 +732,10 @@ class NodeRunner(EventloopMixin):
         but when we are a node that stores an asset from a later node,
         we need to mark the asset as done manually.
         """
-        # one might suspect that we might want to do something like this here
-        # if not self.scheduler.epoch_completed(msg.value):
-        #     async with self._ready_condition:
-        #         self.scheduler.end_epoch(msg.value)
-        #         self._ready_condition.notify_all()
-        # and that suspicion might be correct, but we also might get messages out of order
-        # and get an EpochCompletedError if we get an event from that epoch after the EpochCompleted
-        # message. so until this is a problem in some real tube, we let events drive scheduling.
+        if not self.scheduler.epoch_completed(msg.value):
+            async with self._ready_condition:
+                self.scheduler.end_epoch(msg.value)
+                self._ready_condition.notify_all()
 
         if self.state.dependencies and not self._assets_done(msg.value + 1):
             with contextlib.suppress(AlreadyDoneError):

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -729,13 +729,14 @@ class NodeRunner(EventloopMixin):
         we need to mark the asset as done manually.
         """
         if not self.scheduler.epoch_completed(msg.value):
-            with self._ready_condition:
+            async with self._ready_condition:
                 self.scheduler.end_epoch(msg.value)
                 self._ready_condition.notify_all()
         if self.state.dependencies and not self._assets_done(msg.value + 1):
-            with contextlib.suppress(AlreadyDoneError), self._ready_condition:
-                self.scheduler.done(epoch=msg.value + 1, node_id="assets")
-                self._ready_condition.notify_all()
+            with contextlib.suppress(AlreadyDoneError):
+                async with self._ready_condition:
+                    self.scheduler.done(epoch=msg.value + 1, node_id="assets")
+                    self._ready_condition.notify_all()
 
     async def await_node(self, epoch: Epoch | None = None) -> list[MetaEvent]:
         """

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -575,6 +575,7 @@ class NodeRunner(EventloopMixin):
         elif message.type_ == MessageType.ping:
             await self.identify()
         elif message.type_ == MessageType.epoch_ended:
+            message = cast(EpochEndedMsg, message)
             await self.on_epoch_ended(message)
         else:
             # log but don't throw - other nodes shouldn't be able to crash us

--- a/packages/noob/src/noob/runner/zmq/runner.py
+++ b/packages/noob/src/noob/runner/zmq/runner.py
@@ -362,14 +362,12 @@ class ZMQRunner(TubeRunner):
                 )
 
         for e in events:
-            if (
-                e["node_id"] == "meta"
-                and e["signal"] == MetaEventType.EpochEnded
-                and e["value"] in self._epoch_futures
-            ):
-                if not self._epoch_futures[e["value"]].done():
-                    self._epoch_futures[e["value"]].set_result(e["value"])
-                del self._epoch_futures[e["value"]]
+            if e["node_id"] == "meta" and e["signal"] == MetaEventType.EpochEnded:
+                await self.command.epoch_ended(e["value"])
+                if e["value"] in self._epoch_futures:
+                    if not self._epoch_futures[e["value"]].done():
+                        self._epoch_futures[e["value"]].set_result(e["value"])
+                    del self._epoch_futures[e["value"]]
 
     def on_router(self, msg: Message) -> None:
         if isinstance(msg, ErrorMsg):

--- a/packages/noob/src/noob/runner/zmq/runner.py
+++ b/packages/noob/src/noob/runner/zmq/runner.py
@@ -327,7 +327,9 @@ class ZMQRunner(TubeRunner):
             self._logger.debug(f"Ignoring message type {msg.type_}")
             return
 
+        self.command = cast(CommandNode, self.command)
         msg = cast(EventMsg, msg)
+
         # store events (if we are not in freerun mode, where we don't want to store infinite events)
         if not self._ignore_events:
             for event in msg.value:

--- a/packages/noob/src/noob/runner/zmq/runner.py
+++ b/packages/noob/src/noob/runner/zmq/runner.py
@@ -363,7 +363,8 @@ class ZMQRunner(TubeRunner):
 
         for e in events:
             if e["node_id"] == "meta" and e["signal"] == MetaEventType.EpochEnded:
-                await self.command.epoch_ended(e["value"])
+                if len(e["value"]) == 1:
+                    await self.command.epoch_ended(e["value"])
                 if e["value"] in self._epoch_futures:
                     if not self._epoch_futures[e["value"]].done():
                         self._epoch_futures[e["value"]].set_result(e["value"])

--- a/packages/noob/src/noob/state.py
+++ b/packages/noob/src/noob/state.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from noob.asset import Asset, AssetScope, AssetSpecification
 from noob.event import Event, MetaEvent
 from noob.node.base import Edge
-from noob.types import Epoch, NodeID, PythonIdentifier
+from noob.types import NodeID, PythonIdentifier
 
 if sys.version_info < (3, 12):
     from typing_extensions import TypedDict
@@ -125,7 +125,7 @@ class State(BaseModel):
         yield
         self.deinit(scope, edges)
 
-    def collect(self, edges: list[Edge], epoch: Epoch) -> dict | None:
+    def collect(self, edges: list[Edge]) -> dict | None:
         """
         Gather events into a form that can be consumed by a :meth:`.Node.process` method,
         given the collection of inbound edges (usually from :meth:`.Tube.in_edges` ).
@@ -152,17 +152,7 @@ class State(BaseModel):
                 if edge.source_signal not in self.assets:
                     continue
                 asset = self.assets[edge.source_signal]
-                if (
-                    not asset.depends
-                    or asset.depends.split(".")[0] not in self.dependencies
-                    or epoch[0].epoch == asset.stored_at[0].epoch + 1
-                ):
-                    args[edge.target_slot] = asset.obj
-                else:
-                    raise ValueError(
-                        f"Asset not ready to emit for epoch {epoch}: "
-                        f"asset was last stored at epoch {asset.stored_at}."
-                    )
+                args[edge.target_slot] = asset.obj
 
         return None if not args or all(val is None for val in args.values()) else args
 

--- a/packages/noob/src/noob/testing/nodes.py
+++ b/packages/noob/src/noob/testing/nodes.py
@@ -225,9 +225,10 @@ def zip_iter(*args: Iterator) -> tuple[Any, ...]:
 
 
 def increment(
-    iterator: Iterator[int],
+    iterator: Iterator[int], increment: int = 1
 ) -> tuple[A[Iterator[int], Name("iterator")], A[int, Name("value")]]:
-    value = next(iterator)
+    for _ in range(increment):
+        value = next(iterator)
     return iterator, value
 
 

--- a/packages/noob/tests/data/pipelines/asset/asset_deps_gather.yaml
+++ b/packages/noob/tests/data/pipelines/asset/asset_deps_gather.yaml
@@ -1,0 +1,47 @@
+noob_id: testing-asset-deps-gather
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.1.0
+description: |
+  Regression test (#164)
+  A runner-scoped asset can depend on a node after a gather
+
+assets:
+  counter:
+    type: noob.testing.counter
+    params:
+      start: 1
+    scope: runner
+    depends: b.iterator
+
+nodes:
+  a:
+    type: noob.testing.increment
+    depends:
+      - iterator: assets.counter
+  gather:
+    type: gather
+    params:
+      n: 5
+    depends:
+      - value: a.value
+  sum:
+    type: sum
+    depends:
+      - gather.value
+  b:
+    type: noob.testing.increment
+    depends:
+      - iterator: a.iterator
+      - increment: sum.value
+  post_depends:
+    type: noob.testing.increment
+    depends:
+      - iterator: b.iterator
+  return:
+    type: return
+    depends:
+      - a_value: a.value
+      - b_value: b.value
+      - post_value: post_depends.value
+      - gathered: gather.value
+      - sum: sum.value

--- a/packages/noob/tests/test_pipelines/test_asset.py
+++ b/packages/noob/tests/test_pipelines/test_asset.py
@@ -125,6 +125,33 @@ async def test_asset_copy_post_depends(loaded_tube, all_runners):
             )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("loaded_tube", ["testing-asset-deps-gather"], indirect=True)
+async def test_asset_depends_post_gather(loaded_tube, all_runners):
+    """
+    Regression test (#164)
+    An asset should be able to depend on an event downstream from a gather -
+    i.e. assets shouldn't try and do scheduler things by protecting the asset from being collected
+    in a nonsequential epoch.
+    """
+    runner = all_runners
+    last_b = 0
+    for i in range(15):
+        if iscoroutinefunction_partial(runner.process):
+            result = await runner.process()
+        else:
+            result = runner.process()
+        if (i + 1) % 5 != 0 or i == 0:
+            if not isinstance(runner, ZMQRunner):
+                assert result is None
+        else:
+            # should have incremented by (n_gather) + (sum(gathered values)) and NOT by that + 1
+            assert result["b_value"] == 5 + result["sum"] + last_b
+            assert result["post_value"] == result["b_value"] + 1
+            assert result["a_value"] == last_b + 5
+            last_b = result["b_value"]
+
+
 def test_asset_nocopy_when_unused():
     """
     Don't copy assets when there is no chance for them to be mutated after they are stored


### PR DESCRIPTION
Fix: #164 

Few things here. first is that only the scheduler should be in charge of handling when we do things. the State shouldn't try and protect us from temporal problems, that's not its responsibility. 

This protection was added for the zmqrunner, since the other runners only run one epoch at a time. zmqrunner handles its own epoch timing, so the store doesn't need to do this. 

just removing the check fixed it for the other two nodes, but for the zmqrunner, we run into the problem of "the epoch ended at some point downstream of us, but we can't know that we won't be getting an updated asset since we don't know when the root epoch ends in our nodes. so now we do - zmqrunner, the only one with a full scheduler, tells the nodes when the epoch has ended. most of the time this does nothing, but for nodes with asset dependencies it does something! and this is generally the kind of thing that nodes should be able to know, since working around it is tedious and error prone.

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--170.org.readthedocs.build/en/170/

<!-- readthedocs-preview noob end -->