### PR TITLE
json schema - forbid extras in specs

### DIFF
--- a/packages/noob/src/noob/asset.py
+++ b/packages/noob/src/noob/asset.py
@@ -68,6 +68,8 @@ class AssetSpecification(BaseModel):
     description: str | None = None
     """An optional description of the asset"""
 
+    model_config = ConfigDict(extra="forbid")
+
     @model_validator(mode="after")
     def validate_depends(self) -> Self:
         """

--- a/packages/noob/src/noob/input.py
+++ b/packages/noob/src/noob/input.py
@@ -5,7 +5,7 @@ from enum import StrEnum
 from functools import cached_property
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 from noob.exceptions import ExtraInputWarning, InputMissingError
 from noob.node.base import Edge
@@ -44,6 +44,8 @@ class InputSpecification(BaseModel):
     default: Any | None = None
     description: str | None = None
     """An optional description of the input value"""
+
+    model_config = ConfigDict(extra="forbid")
 
     __get_pydantic_json_schema__ = classmethod(id_optional_json_schema)  # type: ignore[var-annotated]
 

--- a/packages/noob/src/noob/node/spec.py
+++ b/packages/noob/src/noob/node/spec.py
@@ -1,7 +1,7 @@
 from typing import Annotated, TypeAlias
 
 from annotated_types import Len
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from noob.types import AbsoluteIdentifier, DependencyIdentifier, PythonIdentifier
 from noob.yaml import id_optional_json_schema
@@ -122,6 +122,8 @@ class NodeSpecification(BaseModel):
     """
     description: str | None = None
     """An optional description of the node"""
+
+    model_config = ConfigDict(extra="forbid")
 
     @field_validator("depends", mode="after")
     @classmethod

--- a/packages/noob/src/noob/tube.py
+++ b/packages/noob/src/noob/tube.py
@@ -50,6 +50,8 @@ class TubeSpecification(ConfigYAMLMixin):
     description: str | None = None
     """An optional description of the tube"""
 
+    model_config = ConfigDict(extra="forbid")
+
     @field_validator("nodes", "assets", "input", mode="before")
     @classmethod
     def fill_node_ids(cls, value: dict[str, dict]) -> dict[str, dict]:

--- a/schema/asset.schema.json
+++ b/schema/asset.schema.json
@@ -12,6 +12,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "description": "Specification for a single asset within a tube .yaml file.",
   "properties": {
     "id": {

--- a/schema/input.schema.json
+++ b/schema/input.schema.json
@@ -12,6 +12,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "description": "Specification of inputs to a noob tube.\n\nInputs can be supplied at different times and frequencies,\nas specified by `scope`:\n\n- `tube`: When instantiating the tube\n- `process`: Per call to :meth:`.TubeRunner.process`\n\n`tube`-scoped inputs may be used in a node's `param` specification,\nand `process`-scoped inputs may be used as one of a node's `depends`.\n\nInputs can be supplied at a \"higher\" scope and be accessed by lower scopes:\ne.g. input requested with a process scope can use input provided when instantiating the tube,\nif not provided to process but provided to the tube.",
   "properties": {
     "id": {

--- a/schema/node.schema.json
+++ b/schema/node.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/miniscope/noob/tree/v0.1.2/schema/node.schema.json",
+  "additionalProperties": false,
   "description": "Specification for a single processing node within a tube .yaml file.",
   "properties": {
     "type": {

--- a/schema/tube.schema.json
+++ b/schema/tube.schema.json
@@ -12,6 +12,7 @@
       "type": "string"
     },
     "AssetSpecification": {
+      "additionalProperties": false,
       "description": "Specification for a single asset within a tube .yaml file.",
       "properties": {
         "id": {
@@ -80,6 +81,7 @@
       "type": "string"
     },
     "InputSpecification": {
+      "additionalProperties": false,
       "description": "Specification of inputs to a noob tube.\n\nInputs can be supplied at different times and frequencies,\nas specified by `scope`:\n\n- `tube`: When instantiating the tube\n- `process`: Per call to :meth:`.TubeRunner.process`\n\n`tube`-scoped inputs may be used in a node's `param` specification,\nand `process`-scoped inputs may be used as one of a node's `depends`.\n\nInputs can be supplied at a \"higher\" scope and be accessed by lower scopes:\ne.g. input requested with a process scope can use input provided when instantiating the tube,\nif not provided to process but provided to the tube.",
       "properties": {
         "id": {
@@ -124,6 +126,7 @@
       "type": "object"
     },
     "NodeSpecification": {
+      "additionalProperties": false,
       "description": "Specification for a single processing node within a tube .yaml file.",
       "properties": {
         "type": {
@@ -214,6 +217,7 @@
       "type": "object"
     }
   },
+  "additionalProperties": false,
   "description": "Configuration for the nodes within a tube.\n\nRepresentation of the yaml-form of a tube.\nConverted to the runtime-form with :meth:`.Tube.from_specification`.\n\nNot much, if any validation is performed here on the whole tube except\nthat the nodes have the correct fields, ignoring validity of\ne.g. type mismatches or dependencies on signals that don't exist.\nThose require importing and introspecting the specified node classes,\nwhich should only happen when we try and instantiate the tube -\nthis class is just a carrier for the yaml spec.",
   "properties": {
     "noob_id": {


### PR DESCRIPTION
following #190 

whoopsie - had this written but not committed. forbid extras in spec objects so that we are alerted when we add extra invalid things!

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--191.org.readthedocs.build/en/191/

<!-- readthedocs-preview noob end -->