### PR TITLE
fix race condition causing subepoch mismatch from run order within a graph generation

### DIFF
--- a/packages/noob/src/noob/scheduler.py
+++ b/packages/noob/src/noob/scheduler.py
@@ -137,6 +137,8 @@ class Scheduler:
                 sorter.done(parent_dep)
             elif parent_dep in parent_epoch.done_nodes and parent_dep not in exclude_current:
                 sorter.mark_expired(parent_dep, unlock_optionals=False)
+            elif parent_dep in parent_epoch.out_nodes:
+                sorter.mark_out(parent_dep)
 
         self._epochs[epoch] = sorter
         for parent in epoch.parents:

--- a/packages/noob/tests/test_scheduler.py
+++ b/packages/noob/tests/test_scheduler.py
@@ -405,7 +405,18 @@ def test_subepoch_generation_race_condition():
     assert len(ready) == 0
 
     # then when count is done, all the exclaim nodes in the subepoch should be ready.
-    scheduler.update([Event(id=4, timestamp=datetime.now(UTC), node_id="count", signal="index", epoch=ep, value=4)])
+    scheduler.update(
+        [
+            Event(
+                id=4,
+                timestamp=datetime.now(UTC),
+                node_id="count",
+                signal="index",
+                epoch=ep,
+                value=4,
+            )
+        ]
+    )
     ready = scheduler.get_ready(ep)
     assert len(ready) == 3
     assert all(len(r["epoch"]) > 1 for r in ready)

--- a/packages/noob/tests/test_scheduler.py
+++ b/packages/noob/tests/test_scheduler.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from multiprocessing import Queue
 from queue import Empty
 
@@ -366,3 +366,47 @@ def test_upstream_nodes(optional_graph):
     # the rest are just direct dependencies and that's the `Node.edges` method, so not tested here.
     assert not any(e.source_node == "b" and e.target_node == "d" for e in optional_graph)
     assert sched.upstream_nodes("d") == {"b", "c"}
+
+
+def test_subepoch_generation_race_condition():
+    """
+    Nodes in a parent epoch are not incorrectly run in subepochs
+    when a race condition exists between the `map` node and the parent epoch nodes.
+
+    References:
+        https://github.com/miniscope/noob/issues/193
+
+    """
+    tube = Tube.from_specification("testing-map-depends")
+    scheduler = tube.scheduler
+    ep = scheduler.add_epoch()
+    ready = scheduler.get_ready(ep)
+    assert set([r["value"] for r in ready]) == {"word", "count"}
+
+    # word completes first and is then mapped
+    scheduler.done(ep, node_id="word")
+    ready = scheduler.get_ready()
+    assert set([r["value"] for r in ready]) == {"map"}
+
+    # simulate the map events creating subepochs
+    subepochs = ep.make_subepochs("map", 3)
+    events = [
+        Event(
+            id=i, timestamp=datetime.now(UTC), node_id="map", signal="value", epoch=subep, value=i
+        )
+        for i, subep in enumerate(subepochs)
+    ] + [Event(id=3, timestamp=datetime.now(UTC), node_id="map", signal="n", epoch=ep, value=3)]
+    scheduler.update(events)
+
+    # next node in subepoch "exclaim" depends on count, which is not done yet
+    # we should not have accidentally yielded count in the subepochs here
+    # because it wasn't done in the parent.
+    ready = scheduler.get_ready(ep)
+    assert len(ready) == 0
+
+    # then when count is done, all the exclaim nodes in the subepoch should be ready.
+    scheduler.done(ep, node_id="count")
+    ready = scheduler.get_ready(ep)
+    assert len(ready) == 3
+    assert all(len(r["epoch"]) > 1 for r in ready)
+    assert set(r["value"] for r in ready) == {"exclaim"}

--- a/packages/noob/tests/test_scheduler.py
+++ b/packages/noob/tests/test_scheduler.py
@@ -405,7 +405,7 @@ def test_subepoch_generation_race_condition():
     assert len(ready) == 0
 
     # then when count is done, all the exclaim nodes in the subepoch should be ready.
-    scheduler.done(ep, node_id="count")
+    scheduler.update([Event(id=4, timestamp=datetime.now(UTC), node_id="count", signal="index", epoch=ep, value=4)])
     ready = scheduler.get_ready(ep)
     assert len(ready) == 3
     assert all(len(r["epoch"]) > 1 for r in ready)


### PR DESCRIPTION
fix: #193 

first committing correctly failing test, then committing fix

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--197.org.readthedocs.build/en/197/

<!-- readthedocs-preview noob end -->