### PR TITLE
make slot and signal accessors class methods

### DIFF
--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -52,7 +52,9 @@ class Slot(BaseModel):
         slots = {}
         sig = inspect.signature(func)
 
-        for name, param in sig.parameters.items():
+        for i, (name, param) in enumerate(sig.parameters.items()):
+            if i == 0 and name == "self":
+                continue
             slots[name] = Slot(
                 name=name,
                 annotation=param.annotation,
@@ -74,6 +76,8 @@ class Signal(BaseModel):
         return_annotation = inspect.signature(func).return_annotation
         for name, type_ in cls._collect_signal_names(return_annotation):
             signals.append(Signal(name=name, type_=type_))
+        if not signals:
+            signals = [Signal(name="value", type_=Any)]
         return signals
 
     @classmethod
@@ -294,20 +298,43 @@ class Node(BaseModel):
 
     @property
     def signals(self) -> list[Signal]:
+        """
+        Cached instance-level accessor for signals.
+
+        Uses :meth:`.get_signals` and stores the result for frequent access.
+        """
         if self._signals is None:
-            self._signals = self._collect_signals()
-        if not self._signals:
-            self._signals = [Signal(name="value", type_=Any)]
+            self._signals = self.get_signals(self.spec)
         return self._signals
 
-    def _collect_signals(self) -> list[Signal]:
-        return Signal.from_callable(self.process)
+    @classmethod
+    def get_signals(cls, spec: NodeSpecification | None = None) -> list[Signal]:
+        """
+        Public class method for computing signals from a node class and a specification.
+
+        Exposed as a class method for reflection purposes -
+        we don't want to have to instantiate a node to tell what would come out of it,
+        but signals can be dynamically computed by the node depending on its spec.
+
+        If signals can't be computed (because they are not annotated, etc.),
+        returns a generic "value" signal that refers to whatever the node produces.
+
+        Base implementation reads annotations from the process method and does not use the spec.
+        If subclass overrides need a spec to compute their signals,
+        they must raise a ValueError if none is provided.
+        """
+        return Signal.from_callable(cls.process)
 
     @property
     def slots(self) -> dict[str, Slot]:
         if self._slots is None:
-            self._slots = self._collect_slots()
+            self._slots = self.get_slots(self.spec)
         return self._slots
+
+    @classmethod
+    def get_slots(cls, spec: NodeSpecification | None = None) -> dict[str, Slot]:
+        """Similar to :meth:`.get_signals`, but for slots!"""
+        return Slot.from_callable(cls.process)
 
     @property
     def edges(self) -> list[Edge]:
@@ -398,9 +425,6 @@ class Node(BaseModel):
         """
         return iscoroutinefunction_partial(self.process)
 
-    def _collect_slots(self) -> dict[str, Slot]:
-        return Slot.from_callable(self.process)
-
     def _wrap_generator(self, proc: Callable[[], GeneratorType]) -> None:
         """
         Wrap a `process` method when it is a generator,
@@ -468,13 +492,26 @@ class WrapClassNode(Node):
     def deinit(self) -> None:
         self.instance = None
 
-    def _collect_signals(self) -> list[Signal]:
-        return Signal.from_callable(self.process)
+    @classmethod
+    def get_signals(cls, spec: NodeSpecification | None = None) -> list[Signal]:
+        if spec is None:
+            raise ValueError("Must pass a specification to get signals for wrapped nodes")
+        wrapped_cls = resolve_python_identifier(spec.type_)
+        fn_name = cls._get_process_method(wrapped_cls)
+        fn = getattr(wrapped_cls, fn_name)
+        return Signal.from_callable(fn)
 
-    def _collect_slots(self) -> dict[str, Slot]:
-        return Slot.from_callable(self.process)
+    @classmethod
+    def get_slots(cls, spec: NodeSpecification | None = None) -> dict[str, Slot]:
+        if spec is None:
+            raise ValueError("Must pass a specification to get slots for wrapped nodes")
+        wrapped_cls = resolve_python_identifier(spec.type_)
+        fn_name = cls._get_process_method(wrapped_cls)
+        fn = getattr(wrapped_cls, fn_name)
+        return Slot.from_callable(fn)
 
-    def _get_process_method(self, cls: type) -> str:
+    @staticmethod
+    def _get_process_method(cls: type) -> str:
         process_func = None
         for name, member in inspect.getmembers(cls, predicate=inspect.isfunction):
             if hasattr(member, _PROCESS_METHOD_SENTINEL):
@@ -532,8 +569,16 @@ class WrapFuncNode(Node):
         value.stateful = bool(inspect.isgeneratorfunction(value.fn))
         return value
 
-    def _collect_signals(self) -> list[Signal]:
-        return Signal.from_callable(self.fn)
+    @classmethod
+    def get_signals(cls, spec: NodeSpecification | None = None) -> list[Signal]:
+        if spec is None:
+            raise ValueError("Must pass a specification to get signals for wrapped nodes")
+        fn = resolve_python_identifier(spec.type_)
+        return Signal.from_callable(fn)
 
-    def _collect_slots(self) -> dict[str, Slot]:
-        return Slot.from_callable(self.fn)
+    @classmethod
+    def get_slots(cls, spec: NodeSpecification | None = None) -> dict[str, Slot]:
+        if spec is None:
+            raise ValueError("Must pass a specification to get slots for wrapped nodes")
+        fn = resolve_python_identifier(spec.type_)
+        return Slot.from_callable(fn)

--- a/packages/noob/src/noob/node/gather.py
+++ b/packages/noob/src/noob/node/gather.py
@@ -9,6 +9,7 @@ from pydantic import PrivateAttr
 from noob.event import Event, MetaSignal
 from noob.node import Slot
 from noob.node.base import Node
+from noob.node.spec import NodeSpecification
 from noob.types import Epoch
 
 _TInput = TypeVar("_TInput")
@@ -89,18 +90,17 @@ class Gather(Node, Generic[_TInput]):
                     self._items = []
             return MetaSignal.NoEvent
 
-    def _collect_slots(self) -> dict[str, Slot]:
+    @classmethod
+    def get_slots(cls, spec: NodeSpecification | None = None) -> dict[str, Slot]:
         slots = {
             "value": Slot(name="value", annotation=Any),
             "epoch": Slot(name="epoch", annotation=Epoch),
             "trigger": Slot(name="trigger", annotation=Any | None, required=False),
         }
         if (
-            self.spec
-            and self.spec.depends
-            and any(
-                next(iter(dep.keys())) == "n" for dep in self.spec.depends if isinstance(dep, dict)
-            )
+            spec
+            and spec.depends
+            and any(next(iter(dep.keys())) == "n" for dep in spec.depends if isinstance(dep, dict))
         ):
             slots["n"] = Slot(name="n", annotation=int | None, required=True)
         else:

--- a/packages/noob/src/noob/node/return_.py
+++ b/packages/noob/src/noob/node/return_.py
@@ -9,6 +9,7 @@ from pydantic import PrivateAttr
 
 from noob.event import MetaSignal
 from noob.node.base import Node, Slot
+from noob.node.spec import NodeSpecification
 from noob.types import Epoch, EventMap
 
 
@@ -73,13 +74,14 @@ class Return(Node):
                 self._kwargs = defaultdict(list)
                 self._seen_epochs = set()
 
-    def _collect_slots(self) -> dict[str, Slot]:
-        if self.spec is None or not self.spec.depends:
+    @classmethod
+    def get_slots(cls, spec: NodeSpecification | None = None) -> dict[str, Slot]:
+        if spec is None or not spec.depends:
             raise ValueError("Return nodes must have a specification that defines what they return")
-        if isinstance(self.spec.depends, str):
+        if isinstance(spec.depends, str):
             return {}
         slots = {}
-        for dep in self.spec.depends:
+        for dep in spec.depends:
             if isinstance(dep, str):
                 continue
             name = list(dep.keys())[0]

--- a/packages/noob/src/noob/node/tube.py
+++ b/packages/noob/src/noob/node/tube.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Union
 from noob.event import Event
 from noob.exceptions import ExtraInputWarning
 from noob.node.base import Node, Slot
+from noob.node.spec import NodeSpecification
 from noob.types import ConfigSource, Epoch, RunnerContext
 
 if TYPE_CHECKING:
@@ -71,11 +72,20 @@ class TubeNode(Node):
         else:
             return res
 
-    def _collect_slots(self) -> dict[str, Slot]:
+    @classmethod
+    def get_slots(cls, spec: NodeSpecification | None = None) -> dict[str, Slot]:
+        if spec is None:
+            raise ValueError("Must pass a spec to get slots for a tube node")
+
         from noob.input import InputScope
+        from noob.tube import TubeSpecification
+
+        if not spec.params or "tube" not in spec.params:
+            raise ValueError("Tube node specifications must have a `tube` in their params")
+        tube_spec = TubeSpecification.from_any(spec.params["tube"])
 
         slots = {}
-        for in_key, in_val in self.tube_spec.input.items():
+        for in_key, in_val in tube_spec.input.items():
             if in_val.scope == InputScope.process:
                 slots[in_key] = Slot(name=in_key, annotation=Any)
         return slots


### PR DESCRIPTION
we need this for the GUI, and for spec reflection generally - currently one needs to instantiate the nodes in order to get their signals and slots, because some nodes have dynamically computed signals and slots that are dependent on their specification, and others like the wrap nodes need to locate the appropriate callable to treat as the process method. however this is likely to be pretty fragile for cases where we want to be operating on the metadata level re: a tube - some downstream node could do a lot of work on initialization, and we don't want to have to do it when all we want is to tell what some node emits and receives.

so this just makes them classmethods that accept a spec - by default the spec isn't needed, but subclasses may require it if they do.

we still need a convenience accessor to go from spec -> node class -> signals/slots, that logic for deciding what node class to use is still wrapped up in the tube creation process, but i'll do that in another PR.

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--211.org.readthedocs.build/en/211/

<!-- readthedocs-preview noob end -->