### PR TITLE
convert signals from a list to a dict to match slots

### DIFF
--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -71,13 +71,13 @@ class Signal(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
-    def from_callable(cls, func: Callable) -> list["Signal"]:
-        signals = []
+    def from_callable(cls, func: Callable) -> dict[str, "Signal"]:
+        signals = {}
         return_annotation = inspect.signature(func).return_annotation
         for name, type_ in cls._collect_signal_names(return_annotation):
-            signals.append(Signal(name=name, type_=type_))
+            signals[name] = Signal(name=name, type_=type_)
         if not signals:
-            signals = [Signal(name="value", type_=Any)]
+            signals["value"] = Signal(name="value", type_=Any)
         return signals
 
     @classmethod
@@ -196,7 +196,7 @@ class Node(BaseModel):
     * Function nodes are considered stateless
     """
 
-    _signals: list[Signal] | None = None
+    _signals: dict[str, Signal] | None = None
     _slots: dict[str, Slot] | None = None
     _gen: Generator | None = None
     _edges: list[Edge] | None = None
@@ -297,7 +297,7 @@ class Node(BaseModel):
             )
 
     @property
-    def signals(self) -> list[Signal]:
+    def signals(self) -> dict[str, Signal]:
         """
         Cached instance-level accessor for signals.
 
@@ -308,7 +308,7 @@ class Node(BaseModel):
         return self._signals
 
     @classmethod
-    def get_signals(cls, spec: NodeSpecification | None = None) -> list[Signal]:
+    def get_signals(cls, spec: NodeSpecification | None = None) -> dict[str, Signal]:
         """
         Public class method for computing signals from a node class and a specification.
 
@@ -493,7 +493,7 @@ class WrapClassNode(Node):
         self.instance = None
 
     @classmethod
-    def get_signals(cls, spec: NodeSpecification | None = None) -> list[Signal]:
+    def get_signals(cls, spec: NodeSpecification | None = None) -> dict[str, Signal]:
         if spec is None:
             raise ValueError("Must pass a specification to get signals for wrapped nodes")
         wrapped_cls = resolve_python_identifier(spec.type_)
@@ -570,7 +570,7 @@ class WrapFuncNode(Node):
         return value
 
     @classmethod
-    def get_signals(cls, spec: NodeSpecification | None = None) -> list[Signal]:
+    def get_signals(cls, spec: NodeSpecification | None = None) -> dict[str, Signal]:
         if spec is None:
             raise ValueError("Must pass a specification to get signals for wrapped nodes")
         fn = resolve_python_identifier(spec.type_)

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -479,7 +479,7 @@ class NodeRunner(EventloopMixin):
                     node_id=self.spec.id,
                     status=self.status,
                     outbox=self.outbox_address,
-                    signals=[s.name for s in self._node.signals] if self._node.signals else None,
+                    signals=list(self._node.signals) if self._node.signals else None,
                     slots=(
                         [slot_name for slot_name in self._node.slots] if self._node.slots else None
                     ),
@@ -681,7 +681,7 @@ class NodeRunner(EventloopMixin):
                 value = list(combined.values())
             async with self._ready_condition:
                 events = self.store.add_value(
-                    [Signal(name=k, type_=None) for k in combined],
+                    {k: Signal(name=k, type_=None) for k in combined},
                     value,
                     node_id="input",
                     epoch=msg.value["epoch"],

--- a/packages/noob/src/noob/store.py
+++ b/packages/noob/src/noob/store.py
@@ -69,7 +69,7 @@ class EventStore:
         return event
 
     def add_value(
-        self, signals: list[Signal], value: Any, node_id: str, epoch: Epoch
+        self, signals: dict[str, Signal], value: Any, node_id: str, epoch: Epoch
     ) -> list[Event]:
         """
         Add the result of a :meth:`.Node.process` call to the event store.
@@ -86,7 +86,7 @@ class EventStore:
             if the emitted events have incorrect epochs, signals, etc.
 
         Args:
-            signals (list[Signal]): Signals from which the value was emitted by
+            signals (dict[str, Signal]): Signals from which the value was emitted by
                 a :meth:`.Node.process` call
             value (Any): Value emitted by a :meth:`.Node.process` call. Gets wrapped
                 with a list in case the length of signals is 1. Otherwise, it's zipped
@@ -115,7 +115,7 @@ class EventStore:
                         timestamp=timestamp,
                         node_id=node_id,
                         epoch=epoch,
-                        signal=signal.name,
+                        signal=signal,
                         value=val,
                     )
                     self.add(new_event)

--- a/packages/noob/tests/node/test_wrap.py
+++ b/packages/noob/tests/node/test_wrap.py
@@ -13,14 +13,14 @@ from noob.node.base import Node, Signal
         (
             "noob.testing.CountSource",
             {"limit": 10, "start": 5},
-            [Signal(name="index", type_=int)],
+            {"index": Signal(name="index", type_=int)},
         ),
         (
             "noob.testing.UnannotatedGenerator",
             {"limit": 10, "start": 5},
-            [Signal(name="value", type_=Any)],
+            {"value": Signal(name="value", type_=Any)},
         ),
-        ("noob.testing.Multiply", {}, [Signal(name="product", type_=int)]),
+        ("noob.testing.Multiply", {}, {"product": Signal(name="product", type_=int)}),
     ],
 )
 def test_subclass(type_, params, expected):
@@ -44,7 +44,7 @@ def test_class_with_process():
     node.init()
     assert node.process(width=2, depth=3) == 5 * 2 * 3
     assert set(node.slots) == {"width", "depth"}
-    assert node.signals == [Signal(name="volume", type_=int)]
+    assert node.signals == {"volume": Signal(name="volume", type_=int)}
 
 
 def test_class_without_process():

--- a/packages/noob/tests/test_runners/test_zmq.py
+++ b/packages/noob/tests/test_runners/test_zmq.py
@@ -44,7 +44,7 @@ def test_message_roundtrip():
             node_id=node.spec.id,
             status=NodeStatus.ready,
             outbox="ipc:///abc/123",
-            signals=[s.name for s in node.signals],
+            signals=list(node.signals),
             slots=[s for s in node.slots],
         ),
     )

--- a/packages/noob/tests/test_store.py
+++ b/packages/noob/tests/test_store.py
@@ -63,7 +63,10 @@ def test_store_handles_empty_sequences():
     """
     store = EventStore()
     e = store.add_value(
-        [Signal(name="something", type_=str), Signal(name="something_else", type_=str)],
+        {
+            "something": Signal(name="something", type_=str),
+            "something_else": Signal(name="something_else", type_=str),
+        },
         value=[[], []],
         node_id="a",
         epoch=Epoch(0),


### PR DESCRIPTION
For some reason the return type of slots was `dict[str, Slot]` and the return type of signals was `list[Signal]`.

pointlessly different signature for two closely related things. just make them the same.

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--212.org.readthedocs.build/en/212/

<!-- readthedocs-preview noob end -->