### PR TITLE
Get NodeInfo

### DIFF
--- a/packages/noob/src/noob/node/__init__.py
+++ b/packages/noob/src/noob/node/__init__.py
@@ -1,8 +1,11 @@
-from noob.node.spec import NodeSpecification  # noqa: I001 - needs to be defined before Node is
-from noob.node.base import Edge, Node, process_method, Signal, Slot
-from noob.node.return_ import Return
+from noob.node.spec import (  # noqa: I001 - needs to be defined before Node is
+    NodeInfo,
+    NodeSpecification,
+)
+from noob.node.base import Edge, Node, Signal, Slot, process_method
 from noob.node.gather import Gather
 from noob.node.map import Map
+from noob.node.return_ import Return
 from noob.node.tube import TubeNode
 
 SPECIAL_NODES = {"gather": Gather, "map": Map, "return": Return, "tube": TubeNode}
@@ -16,6 +19,7 @@ __all__ = [
     "Gather",
     "Map",
     "Node",
+    "NodeInfo",
     "NodeSpecification",
     "Return",
     "Signal",

--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -65,7 +65,7 @@ class Slot(BaseModel):
 
 class Signal(BaseModel):
     name: str
-    type_: type | None | UnionType | GenericAlias | _UnionGenericAlias
+    annotation: type | None | UnionType | GenericAlias | _UnionGenericAlias
 
     # Unable to generate pydantic-core schema for <class 'types.UnionType'>
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -75,9 +75,9 @@ class Signal(BaseModel):
         signals = {}
         return_annotation = inspect.signature(func).return_annotation
         for name, type_ in cls._collect_signal_names(return_annotation):
-            signals[name] = Signal(name=name, type_=type_)
+            signals[name] = Signal(name=name, annotation=type_)
         if not signals:
-            signals["value"] = Signal(name="value", type_=Any)
+            signals["value"] = Signal(name="value", annotation=Any)
         return signals
 
     @classmethod

--- a/packages/noob/src/noob/node/spec.py
+++ b/packages/noob/src/noob/node/spec.py
@@ -131,7 +131,7 @@ class NodeSpecification(BaseModel):
     description: str | None = None
     """An optional description of the node"""
 
-    model_config = ConfigDict(extra="forbid", serialize_by_alias=True, frozen=True)
+    model_config = ConfigDict(extra="forbid", serialize_by_alias=True)
 
     @field_validator("depends", mode="after")
     @classmethod

--- a/packages/noob/src/noob/node/spec.py
+++ b/packages/noob/src/noob/node/spec.py
@@ -1,10 +1,18 @@
-from typing import Annotated, TypeAlias
+from __future__ import annotations
+
+import inspect
+from functools import cached_property
+from typing import TYPE_CHECKING, Annotated, TypeAlias, TypedDict
 
 from annotated_types import Len
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from noob.types import AbsoluteIdentifier, DependencyIdentifier, PythonIdentifier
+from noob.utils import resolve_python_identifier
 from noob.yaml import id_optional_json_schema
+
+if TYPE_CHECKING:
+    from noob.node.base import Signal, Slot
 
 _DependsBasic: TypeAlias = Annotated[
     dict[PythonIdentifier, DependencyIdentifier], Len(min_length=1, max_length=1)
@@ -123,7 +131,7 @@ class NodeSpecification(BaseModel):
     description: str | None = None
     """An optional description of the node"""
 
-    model_config = ConfigDict(extra="forbid", serialize_by_alias=True)
+    model_config = ConfigDict(extra="forbid", serialize_by_alias=True, frozen=True)
 
     @field_validator("depends", mode="after")
     @classmethod
@@ -143,4 +151,43 @@ class NodeSpecification(BaseModel):
             seen.add(signal)
         return val
 
+    @cached_property
+    def nodeinfo(self) -> NodeInfo:
+        """Information about the node that this spec is for."""
+        from noob.node.base import Node, WrapClassNode, WrapFuncNode
+
+        obj = resolve_python_identifier(self.type_)
+        if inspect.isclass(obj):
+            node_cls = obj if issubclass(obj, Node) else WrapClassNode
+        else:
+            node_cls = WrapFuncNode
+
+        return NodeInfo(
+            node_id=self.id,
+            type=self.type_,
+            signals=node_cls.get_signals(self),
+            slots=node_cls.get_slots(self),
+        )
+
     __get_pydantic_json_schema__ = classmethod(id_optional_json_schema)  # type: ignore[var-annotated]
+
+
+class NodeInfo(TypedDict):
+    """
+    Metadata about the completed spec given the combination of a node spec and a node class.
+
+    The spec if purely static, the node class is *mostly* static,
+    but some important properties - notably signals and slots -
+    can be dynamic: i.e. the signals or slots of the node depend on the spec.
+
+    This metadata is primarily used in visualization or inspection of tubes, rather than at runtime
+    """
+
+    node_id: str
+    """Node ID whose spec this NodeInfo was computed from"""
+    type: str
+    """fully-qualified module.object name for the node type"""
+    signals: dict[str, Signal]
+    """Signals computed from the spec and node class"""
+    slots: dict[str, Slot]
+    """Slots computed from the spec and node class"""

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -681,7 +681,7 @@ class NodeRunner(EventloopMixin):
                 value = list(combined.values())
             async with self._ready_condition:
                 events = self.store.add_value(
-                    {k: Signal(name=k, type_=None) for k in combined},
+                    {k: Signal(name=k, annotation=None) for k in combined},
                     value,
                     node_id="input",
                     epoch=msg.value["epoch"],

--- a/packages/noob/src/noob/testing/__init__.py
+++ b/packages/noob/src/noob/testing/__init__.py
@@ -2,6 +2,7 @@ from noob.testing.assets import AnyAsset, Initializer, counter
 from noob.testing.nodes import (
     CountSource,
     CountSourceDecor,
+    DynamicSignals,
     InitCounter,
     Multiply,
     Now,
@@ -43,6 +44,7 @@ from noob.testing.nodes import (
 
 __all__ = [
     "AnyAsset",
+    "DynamicSignals",
     "async_error",
     "concat",
     "count_source",

--- a/packages/noob/src/noob/testing/nodes.py
+++ b/packages/noob/src/noob/testing/nodes.py
@@ -310,10 +310,14 @@ class DynamicSignals(Node):
 
     @classmethod
     def get_signals(cls, spec: NodeSpecification | None = None) -> dict[str, Signal]:
+        if not spec or not spec.params:
+            return {}
         return {sig: Signal(name=sig, annotation=Any) for sig in spec.params.get("signals_", [])}
 
     @classmethod
     def get_slots(cls, spec: NodeSpecification | None = None) -> dict[str, Slot]:
+        if not spec or not spec.params:
+            return {}
         return {
             sig: Slot(name=sig, annotation=Any, required=True)
             for sig in spec.params.get("slots_", [])

--- a/packages/noob/src/noob/testing/nodes.py
+++ b/packages/noob/src/noob/testing/nodes.py
@@ -9,10 +9,11 @@ from typing import Annotated as A
 from typing import Any
 
 from faker import Faker
+from pydantic import Field
 
-from noob import Name, process_method
+from noob import Name, NodeSpecification, process_method
 from noob.event import MetaSignal
-from noob.node import Node
+from noob.node import Node, Signal, Slot
 from noob.types import Epoch, EventMap
 
 
@@ -296,3 +297,24 @@ def this_or_that(
     if the_other is not None:
         ret["the_other"] = the_other
     return ret
+
+
+class DynamicSignals(Node):
+    """Node whose signals and slots are dynamic"""
+
+    signals_: list[str] = Field(default_factory=list)
+    slots_: list[str] = Field(default_factory=list)
+
+    def process(self, **kwargs: Any) -> Any | None:
+        return tuple(v for v in kwargs.values())
+
+    @classmethod
+    def get_signals(cls, spec: NodeSpecification | None = None) -> dict[str, Signal]:
+        return {sig: Signal(name=sig, annotation=Any) for sig in spec.params.get("signals_", [])}
+
+    @classmethod
+    def get_slots(cls, spec: NodeSpecification | None = None) -> dict[str, Slot]:
+        return {
+            sig: Slot(name=sig, annotation=Any, required=True)
+            for sig in spec.params.get("slots_", [])
+        }

--- a/packages/noob/src/noob/tube.py
+++ b/packages/noob/src/noob/tube.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from collections.abc import Mapping
+from functools import cached_property
 from importlib import resources
 from itertools import permutations
 from typing import Self, cast
@@ -21,7 +22,7 @@ from ruamel.yaml import CommentedMap
 from noob.asset import AssetSpecification
 from noob.exceptions import InputMissingError
 from noob.input import InputCollection, InputScope, InputSpecification
-from noob.node import Edge, Node, NodeSpecification, Return
+from noob.node import Edge, Node, NodeInfo, NodeSpecification, Return
 from noob.scheduler import Scheduler
 from noob.state import State
 from noob.types import ConfigSource, NodeSignal, PythonIdentifier
@@ -170,6 +171,16 @@ class TubeSpecification(ConfigYAMLMixin):
                         node.params = {}
                     node.params["tube"] = TubeSpecification.from_any(node.params["tube"])
         return self
+
+    @cached_property
+    def nodeinfo(self) -> dict[str, NodeInfo]:
+        """
+        Nodeinfo for each node in the tube.
+        Even though NodeInfo typically doesn't vary between multiple instances of the same type,
+        we still create one per node because they *can*,
+        and making that configurable would be bloat compared to the ease of computing it.
+        """
+        return {node_id: spec.nodeinfo for node_id, spec in self.nodes.items()}
 
     @classmethod
     def _post_load_yaml(cls, config: CommentedMap) -> Mapping:

--- a/packages/noob/tests/node/test_spec.py
+++ b/packages/noob/tests/node/test_spec.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+from noob.node import NodeSpecification, Signal, Slot
+
+
+def test_nodeinfo():
+    """NodeInfo can extract slot/signal information from a node class/function"""
+    spec = NodeSpecification(id="test", type="noob.testing.concat")
+    info = spec.nodeinfo
+    assert info["signals"] == {"value": Signal(name="value", annotation=str)}
+    assert info["slots"] == {"strings": Slot(name="strings", annotation=list[str])}
+
+
+def test_dynamic_nodeinfo():
+    """Nodeinfo from a node that computes its nodeinfo from the spec"""
+    spec = NodeSpecification(
+        id="test",
+        type="noob.testing.DynamicSignals",
+        params={"signals_": ["apple", "banana"], "slots_": ["cherry", "diaper"]},
+    )
+    info = spec.nodeinfo
+    assert info["signals"] == {
+        "apple": Signal(name="apple", annotation=Any),
+        "banana": Signal(name="banana", annotation=Any),
+    }
+    assert info["slots"] == {
+        "cherry": Slot(name="cherry", annotation=Any),
+        "diaper": Slot(name="diaper", annotation=Any),
+    }

--- a/packages/noob/tests/node/test_wrap.py
+++ b/packages/noob/tests/node/test_wrap.py
@@ -13,14 +13,14 @@ from noob.node.base import Node, Signal
         (
             "noob.testing.CountSource",
             {"limit": 10, "start": 5},
-            {"index": Signal(name="index", type_=int)},
+            {"index": Signal(name="index", annotation=int)},
         ),
         (
             "noob.testing.UnannotatedGenerator",
             {"limit": 10, "start": 5},
-            {"value": Signal(name="value", type_=Any)},
+            {"value": Signal(name="value", annotation=Any)},
         ),
-        ("noob.testing.Multiply", {}, {"product": Signal(name="product", type_=int)}),
+        ("noob.testing.Multiply", {}, {"product": Signal(name="product", annotation=int)}),
     ],
 )
 def test_subclass(type_, params, expected):
@@ -44,7 +44,7 @@ def test_class_with_process():
     node.init()
     assert node.process(width=2, depth=3) == 5 * 2 * 3
     assert set(node.slots) == {"width", "depth"}
-    assert node.signals == {"volume": Signal(name="volume", type_=int)}
+    assert node.signals == {"volume": Signal(name="volume", annotation=int)}
 
 
 def test_class_without_process():

--- a/packages/noob/tests/test_store.py
+++ b/packages/noob/tests/test_store.py
@@ -64,8 +64,8 @@ def test_store_handles_empty_sequences():
     store = EventStore()
     e = store.add_value(
         {
-            "something": Signal(name="something", type_=str),
-            "something_else": Signal(name="something_else", type_=str),
+            "something": Signal(name="something", annotation=str),
+            "something_else": Signal(name="something_else", annotation=str),
         },
         value=[[], []],
         node_id="a",


### PR DESCRIPTION
building on prior two PRs, chunking this up for review's sake - do those two first.

adds a mechanism to get the signals and slots from a node spec using the clasmethods.

made one another refactoring change to make signals and slots consistent: i think the more accurate thing to call something in the signals/slots models is "annotation", that's what python calls it, and i think we mostly use type in the specs because that's a more familiar word. "what type of node is it?"

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--213.org.readthedocs.build/en/213/

<!-- readthedocs-preview noob end -->