### PR TITLE
Use Nodeinfo when visualizing to draw slots and signals

### DIFF
--- a/docs/_ext/plot.py
+++ b/docs/_ext/plot.py
@@ -41,7 +41,10 @@ class NoobTubePlot(SphinxDirective):
         section = nodes.container(ids=[f"tube-plot-{tube_id_esc}"], classes=["noob-tube-plot"])
         container += section
         container += ScriptNode(
-            SCRIPT_TEMPLATE.format(tube_id=tube_id_esc, tube_spec=spec.model_dump_json())
+            SCRIPT_TEMPLATE.format(
+                tube_id=tube_id_esc,
+                tube_spec=spec.model_dump_json(exclude={"nodes": {"__all__": {"nodeinfo"}}}),
+            )
         )
 
         return [container]

--- a/js/src/tube.tsx
+++ b/js/src/tube.tsx
@@ -20,7 +20,30 @@ import type { Edge } from "@xyflow/react";
  */
 export function tubeToFlow(tube: TubeSpecification): [Edge[], NodeUnion[]] {
   const edges = getEdges(tube.nodes);
-  const nodes = getNodes(tube.nodes, edges);
+  let nodes = getNodes(tube.nodes);
+  // TODO: Dedicated representation of inputs
+  if (tube.input) {
+    nodes = [
+      ...nodes,
+      {
+        id: "input",
+        position: { x: 0, y: 0 },
+        type: "elk",
+        data: {
+          label: "input",
+          targetHandles: [],
+          sourceHandles: Object.values(tube.input).map((i) => {
+            return {
+              id: `input.signals.${i.id}`,
+              label: i.id,
+              key: `input.signals.${i.id}`,
+              required: true,
+            };
+          }),
+        },
+      },
+    ];
+  }
   return [edges, nodes];
 }
 
@@ -109,12 +132,8 @@ function getNodeEdges(node: NoobNode, prefix?: string): Edge[] {
 }
 
 // Get all nodes from a tube spec
-function getNodes(nodes: Record<string, NoobNode>, edges: Edge[]): NodeUnion[] {
-  const has_input = edges.some((e) => e.source === "input");
-  if (has_input) {
-    nodes = { ...nodes, input: { id: "input", type: "input" } };
-  }
-  return Object.values(nodes).flatMap((node) => getNode(node, edges));
+function getNodes(nodes: Record<string, NoobNode>): NodeUnion[] {
+  return Object.values(nodes).flatMap((node) => getNode(node));
 }
 
 /**
@@ -123,27 +142,23 @@ function getNodes(nodes: Record<string, NoobNode>, edges: Edge[]): NodeUnion[] {
  *
  * See: https://reactflow.dev/examples/grouping/sub-flows
  */
-function getNode(node: NoobNode, edges: Edge[], prefix?: string): NodeUnion[] {
+function getNode(node: NoobNode, prefix?: string): NodeUnion[] {
   // Create handle description for node and then filter to unique entries
   if (isTubeNode(node)) {
-    return getTubeNode(node, edges);
+    return getTubeNode(node);
   } else {
-    return getGenericNode(node, edges, prefix);
+    return getGenericNode(node, prefix);
   }
 }
 
-function getGenericNode(
-  node: NoobNode,
-  edges: Edge[],
-  prefix?: string,
-): ElkNodeType[] {
+function getGenericNode(node: NoobNode, prefix?: string): ElkNodeType[] {
   const id = prefix ? `${prefix}.${node.id}` : node.id;
   return [
     {
       id: id,
       data: {
         label: node.id,
-        ...getNodeHandles(node.id, edges, prefix),
+        ...getNodeHandles(node, prefix),
       },
       position: { x: 0, y: 0 },
       type: "elk",
@@ -157,7 +172,7 @@ function getGenericNode(
  *
  * Renders inputs and the return node as handles on the border of an outer grouping node.
  */
-function getTubeNode(node: TubeNode, edges: Edge[]): NodeUnion[] {
+function getTubeNode(node: TubeNode): NodeUnion[] {
   // Make the outer grouping node
   const innerTube = node.params.tube;
   const targetHandles = innerTube.input
@@ -168,6 +183,7 @@ function getTubeNode(node: TubeNode, edges: Edge[]): NodeUnion[] {
             id: `${node.id}.slots.${input.id}`,
             label: input.id,
             key: `${node.id}.slots.${input.id}`,
+            required: true,
           };
         })
     : [];
@@ -186,6 +202,7 @@ function getTubeNode(node: TubeNode, edges: Edge[]): NodeUnion[] {
           id: `${node.id}.signals.${slot}`,
           label: slot,
           key: `${node.id}.signals.${slot}`,
+          required: false, // return node slots are never really required, special case.
         };
       })
     : [];
@@ -205,7 +222,7 @@ function getTubeNode(node: TubeNode, edges: Edge[]): NodeUnion[] {
   // Then the children that go within it
   let childNodes = Object.values(innerTube.nodes)
     .filter((child) => child.type !== "return")
-    .flatMap<NodeUnion>((child) => getNode(child, edges, node.id));
+    .flatMap<NodeUnion>((child) => getNode(child, node.id));
   childNodes = childNodes.map((child) => {
     return {
       ...child,
@@ -218,40 +235,29 @@ function getTubeNode(node: TubeNode, edges: Edge[]): NodeUnion[] {
 
 /**
  * Infer node handles from edges
- * FIXME - read the actual node's signals and slots rather than relying on the spec.
  */
-function getNodeHandles(
-  node_id: string,
-  edges: Edge[],
-  prefix?: string,
-): Handles {
+function getNodeHandles(node: NoobNode, prefix?: string): Handles {
   // righthand signal handles
-  node_id = prefix ? `${prefix}.${node_id}` : node_id;
-  const sourceHandles = edges
-    .filter((e) => e.source === node_id && e.sourceHandle !== undefined)
-    .map((e) => {
-      const label = (e.sourceHandle as string).split(".").at(-1) as string;
-      const id = e.sourceHandle as string;
-      return {
-        id: id,
-        label: label,
-        key: id,
-      };
-    })
-    .filter((e, index, self) => self.map((x) => x.id).indexOf(e.id) === index);
+  const node_id = prefix ? `${prefix}.${node.id}` : node.id;
+  const sourceHandles = Object.values(node.nodeinfo.signals).map((sig) => {
+    const id = `${node_id}.signals.${sig.name}`;
+    return {
+      id: id,
+      label: sig.name,
+      key: id,
+      required: true, // signals don't really have a requiredness...
+    };
+  });
   // lefthand slot handles
-  const targetHandles = edges
-    .filter((e) => e.target === node_id && e.targetHandle !== undefined)
-    .map((e) => {
-      const label = (e.targetHandle as string).split(".").at(-1) as string;
-      const id = e.targetHandle as string;
-      return {
-        id: id,
-        label: label,
-        key: id,
-      };
-    })
-    .filter((e, index, self) => self.map((x) => x.id).indexOf(e.id) === index);
+  const targetHandles = Object.values(node.nodeinfo.slots).map((slot) => {
+    const id = `${node_id}.slots.${slot.name}`;
+    return {
+      id: id,
+      label: slot.name,
+      key: id,
+      required: slot.required,
+    };
+  });
   return { sourceHandles, targetHandles };
 }
 

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -8,6 +8,13 @@ export interface TubeSpecification {
   input?: Record<string, InputSpecification>;
 }
 
+export interface NodeInfo {
+  node_id: string;
+  type: string;
+  signals: Record<string, Signal>;
+  slots: Record<string, Slot>;
+}
+
 export interface InputSpecification {
   id: string;
   type: string;
@@ -27,6 +34,18 @@ export interface NoobNode {
   type: string;
   depends?: Record<string, string>[] | string;
   params?: Record<string, string | object>;
+  nodeinfo: NodeInfo;
+}
+
+export interface Signal {
+  name: string;
+  annotation: string;
+}
+
+export interface Slot {
+  name: string;
+  annotation: string;
+  required: boolean;
 }
 
 export interface TubeNode extends NoobNode {
@@ -38,6 +57,7 @@ export interface Handle {
   id: string;
   label: string;
   key: string;
+  required: boolean;
 }
 
 // Same as below - node class expects type with string keys

--- a/js/tests/data/tubes.ts
+++ b/js/tests/data/tubes.ts
@@ -1,5 +1,8 @@
 import type { TubeSpecification } from "../../src/types";
 
+// placeholder value, not used in tests yet
+const nodeinfo = { node_id: "", type: "", signals: {}, slots: {} };
+
 export const recursiveTube: TubeSpecification = {
   noob_id: "testing-recursive-parent",
   noob_model: "noob.tube.TubeSpecification",
@@ -15,6 +18,7 @@ export const recursiveTube: TubeSpecification = {
       type: "noob.testing.count_source",
       id: "a",
       params: { start: "input.parent_start" },
+      nodeinfo,
     },
     b: {
       type: "tube",
@@ -23,6 +27,7 @@ export const recursiveTube: TubeSpecification = {
         { child_multiply_inner: "a.index" },
         { child_multiply_input: "input.child_multiply" },
       ],
+      nodeinfo,
       params: {
         tube: {
           noob_id: "testing-recursive-child",
@@ -46,6 +51,7 @@ export const recursiveTube: TubeSpecification = {
               type: "noob.testing.count_source",
               id: "a",
               params: { start: "input.child_start" },
+              nodeinfo,
             },
             b: {
               type: "noob.testing.multiply",
@@ -54,6 +60,7 @@ export const recursiveTube: TubeSpecification = {
                 { left: "a.index" },
                 { right: "input.child_multiply_inner" },
               ],
+              nodeinfo,
             },
             c: {
               type: "noob.testing.multiply",
@@ -62,8 +69,9 @@ export const recursiveTube: TubeSpecification = {
                 { left: "b.value" },
                 { right: "input.child_multiply_input" },
               ],
+              nodeinfo,
             },
-            d: { type: "return", id: "d", depends: "c.value" },
+            d: { type: "return", id: "d", depends: "c.value", nodeinfo },
           },
         },
       },
@@ -72,6 +80,7 @@ export const recursiveTube: TubeSpecification = {
       type: "noob.testing.multiply",
       id: "c",
       depends: [{ left: "b.value" }, { right: "input.parent_multiply" }],
+      nodeinfo,
     },
     d: {
       type: "return",
@@ -81,6 +90,7 @@ export const recursiveTube: TubeSpecification = {
         { child: "b.value" },
         { parent: "c.value" },
       ],
+      nodeinfo,
     },
   },
 };

--- a/js/tests/tube.test.ts
+++ b/js/tests/tube.test.ts
@@ -1,7 +1,7 @@
 import { recursiveTube } from "./data/tubes";
 import { test, beforeAll, describe, expect } from "vitest";
 import { tubeToFlow, testExports } from "../src/tube";
-import type { TubeNode, NodeUnion } from "../src/types.ts";
+import type { TubeNode, NodeUnion, NoobNode } from "../src/types.ts";
 import type { Edge } from "@xyflow/react";
 
 const { getNodeEdges, getTubeNode, getEdges } = testExports;
@@ -15,7 +15,8 @@ beforeAll(() => {
   ) as TubeNode;
 });
 
-const baseNode = { id: "test", type: "module.function" };
+const nodeinfo = { node_id: "", type: "", signals: {}, slots: {} };
+const baseNode = { id: "test", type: "module.function", nodeinfo };
 
 describe("getNodeEdges", () => {
   test("handles string dependencies as value signals", () => {
@@ -54,7 +55,12 @@ describe("getNodeEdges", () => {
 
     test("unnests return targets with prefix", () => {
       const edges = getNodeEdges(
-        { id: "test", type: "return", depends: [{ slot: "b.something" }] },
+        {
+          id: "test",
+          type: "return",
+          depends: [{ slot: "b.something" }],
+          nodeinfo,
+        },
         "prefix",
       );
 
@@ -68,13 +74,13 @@ describe("getTubeNode", () => {
   let nodes: NodeUnion[];
 
   beforeAll(() => {
-    nodes = getTubeNode(tubeNode, recursiveEdges);
+    nodes = getTubeNode(tubeNode);
   });
 
   test("removes a return node", () => {
     const return_node = Object.values(tubeNode.params.tube.nodes).find(
       (n) => n.type === "return",
-    ) as NodeUnion;
+    ) as NoobNode;
 
     expect(return_node).toBeDefined();
     expect(nodes).length(4);
@@ -105,8 +111,18 @@ describe("getEdges", () => {
 
   test("differentiates same-named slots and signals", () => {
     const edges = getEdges({
-      a: { id: "a", type: "test.test", depends: [{ value: "z.value" }] },
-      b: { id: "b", type: "test.test", depends: [{ value: "a.value" }] },
+      a: {
+        id: "a",
+        type: "test.test",
+        depends: [{ value: "z.value" }],
+        nodeinfo,
+      },
+      b: {
+        id: "b",
+        type: "test.test",
+        depends: [{ value: "a.value" }],
+        nodeinfo,
+      },
     });
 
     expect(edges[0]).toHaveProperty("targetHandle", "a.slots.value");

--- a/packages/noob/src/noob/edge.py
+++ b/packages/noob/src/noob/edge.py
@@ -1,0 +1,118 @@
+import inspect
+from collections.abc import Callable, Generator
+from types import GenericAlias, UnionType
+from typing import (  # type: ignore[attr-defined]
+    Annotated,
+    Any,
+    _UnionGenericAlias,
+    get_args,
+    get_origin,
+)
+
+from pydantic import BaseModel, ConfigDict
+
+from noob.introspection import is_optional, is_union
+from noob.types import JsonStringable
+
+
+class Slot(BaseModel):
+    name: str
+    annotation: JsonStringable[Any]
+    required: bool = True
+
+    @classmethod
+    def from_callable(cls, func: Callable) -> dict[str, "Slot"]:
+        slots = {}
+        sig = inspect.signature(func)
+
+        for i, (name, param) in enumerate(sig.parameters.items()):
+            if i == 0 and name == "self":
+                continue
+            slots[name] = Slot(
+                name=name,
+                annotation=param.annotation,
+                required=not (is_optional(param.annotation) and param.default is None),
+            )
+        return slots
+
+
+class Signal(BaseModel):
+    name: str
+    annotation: JsonStringable[type | None | UnionType | GenericAlias | _UnionGenericAlias]
+
+    # Unable to generate pydantic-core schema for <class 'types.UnionType'>
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @classmethod
+    def from_callable(cls, func: Callable) -> dict[str, "Signal"]:
+        signals = {}
+        return_annotation = inspect.signature(func).return_annotation
+        for name, type_ in cls._collect_signal_names(return_annotation):
+            signals[name] = Signal(name=name, annotation=type_)
+        if not signals:
+            signals["value"] = Signal(name="value", annotation=Any)
+        return signals
+
+    @classmethod
+    def _collect_signal_names(
+        cls, return_annotation: Annotated[Any, Any]
+    ) -> list[tuple[str, type]]:
+        """
+        Recursive kernel for extracting name attribute of Name metadata from a type annotation.
+        If the outermost origin is `typing.Annotated`, it extracts all Name objects from its
+        arguments and append.
+        If the outermost origin is `tuple` or `Generator`, grab the argument and recurses into
+        this function.
+        If the outermost is `Generator`, or `tuple` but the inner layer isn't one of `Generator`,
+        `tuple`, or `Annotated`, assume it's an unnamed signal (no Name inside).
+        If the outermost is none of `Generator`, `tuple`, or `Annotated`, assume it's an unnamed
+        signal.
+
+        Returns a list of names.
+        """
+        from noob import Name
+
+        default_name = "value"
+        names = []
+
+        # --- get yield type of generators before handling other types
+        if get_origin(return_annotation) is Generator:
+            return_annotation = get_args(return_annotation)[0]
+        # ---
+
+        # def func() -> Annotated[...]
+        if get_origin(return_annotation) is Annotated:
+            for argument in get_args(return_annotation):
+                if isinstance(argument, Name):
+                    names.append((argument.name, get_args(return_annotation)[0]))
+
+        # def func() -> tuple[...]: OR def func() -> A | B:
+        elif get_origin(return_annotation) is tuple or is_union(return_annotation):
+            for argument in get_args(return_annotation):
+                if get_origin(argument) in [Annotated, tuple]:
+                    names += Signal._collect_signal_names(argument)
+                elif argument not in [type(None), None]:
+                    names = [(default_name, return_annotation)]
+
+        # def func() -> type:
+        elif return_annotation and (return_annotation is not inspect.Signature.empty):
+            names = [(default_name, return_annotation)]
+
+        return names
+
+
+class Edge(BaseModel):
+    """
+    Directed connection between an output slot a node and an input slot in another node
+    """
+
+    source_node: str
+    source_signal: str
+    target_node: str
+    target_slot: str | int | None = None
+    """
+    - For kwargs, target_slot is the name of the kwarg that the value is passed to.
+    - For positional arguments, target_slot is an integer that indicates the index of the arg
+    - For scalar arguments, target slot is None 
+    """
+    required: bool = True

--- a/packages/noob/src/noob/input.py
+++ b/packages/noob/src/noob/input.py
@@ -7,8 +7,8 @@ from typing import Any, ClassVar, overload
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
+from noob.edge import Edge
 from noob.exceptions import ExtraInputWarning, InputMissingError
-from noob.node.base import Edge
 from noob.types import AbsoluteIdentifier, PythonIdentifier
 from noob.yaml import id_optional_json_schema
 

--- a/packages/noob/src/noob/node/__init__.py
+++ b/packages/noob/src/noob/node/__init__.py
@@ -2,7 +2,7 @@ from noob.node.spec import (  # noqa: I001 - needs to be defined before Node is
     NodeInfo,
     NodeSpecification,
 )
-from noob.node.base import Edge, Node, Signal, Slot, process_method
+from noob.node.base import Node, process_method
 from noob.node.gather import Gather
 from noob.node.map import Map
 from noob.node.return_ import Return
@@ -15,14 +15,11 @@ Map from short names used in node ``type`` values to special node classes
 
 
 __all__ = [
-    "Edge",
     "Gather",
     "Map",
     "Node",
     "NodeInfo",
     "NodeSpecification",
     "Return",
-    "Signal",
-    "Slot",
     "process_method",
 ]

--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -1,18 +1,15 @@
 import functools
 import inspect
 from collections.abc import Callable, Generator, Mapping
-from types import GeneratorType, GenericAlias, UnionType
-from typing import (  # type: ignore[attr-defined]
+from types import GeneratorType
+from typing import (
     TYPE_CHECKING,
-    Annotated,
     Any,
     Self,
     TypeVar,
     Union,
-    _UnionGenericAlias,
     cast,
     get_args,
-    get_origin,
 )
 
 from pydantic import (
@@ -24,7 +21,7 @@ from pydantic import (
     model_validator,
 )
 
-from noob.introspection import is_optional, is_union
+from noob.edge import Edge, Signal, Slot
 from noob.node.spec import NodeSpecification
 from noob.types import Epoch, EventMap
 from noob.utils import iscoroutinefunction_partial, resolve_python_identifier
@@ -40,110 +37,6 @@ to the types that trigger their injection
 epoch - the current epoch
 events - see EventMap
 """
-
-
-class Slot(BaseModel):
-    name: str
-    annotation: Any
-    required: bool = True
-
-    @classmethod
-    def from_callable(cls, func: Callable) -> dict[str, "Slot"]:
-        slots = {}
-        sig = inspect.signature(func)
-
-        for i, (name, param) in enumerate(sig.parameters.items()):
-            if i == 0 and name == "self":
-                continue
-            slots[name] = Slot(
-                name=name,
-                annotation=param.annotation,
-                required=not (is_optional(param.annotation) and param.default is None),
-            )
-        return slots
-
-
-class Signal(BaseModel):
-    name: str
-    annotation: type | None | UnionType | GenericAlias | _UnionGenericAlias
-
-    # Unable to generate pydantic-core schema for <class 'types.UnionType'>
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    @classmethod
-    def from_callable(cls, func: Callable) -> dict[str, "Signal"]:
-        signals = {}
-        return_annotation = inspect.signature(func).return_annotation
-        for name, type_ in cls._collect_signal_names(return_annotation):
-            signals[name] = Signal(name=name, annotation=type_)
-        if not signals:
-            signals["value"] = Signal(name="value", annotation=Any)
-        return signals
-
-    @classmethod
-    def _collect_signal_names(
-        cls, return_annotation: Annotated[Any, Any]
-    ) -> list[tuple[str, type]]:
-        """
-        Recursive kernel for extracting name attribute of Name metadata from a type annotation.
-        If the outermost origin is `typing.Annotated`, it extracts all Name objects from its
-        arguments and append.
-        If the outermost origin is `tuple` or `Generator`, grab the argument and recurses into
-        this function.
-        If the outermost is `Generator`, or `tuple` but the inner layer isn't one of `Generator`,
-        `tuple`, or `Annotated`, assume it's an unnamed signal (no Name inside).
-        If the outermost is none of `Generator`, `tuple`, or `Annotated`, assume it's an unnamed
-        signal.
-
-        Returns a list of names.
-        """
-        from noob import Name
-
-        default_name = "value"
-        names = []
-
-        # --- get yield type of generators before handling other types
-        if get_origin(return_annotation) is Generator:
-            return_annotation = get_args(return_annotation)[0]
-        # ---
-
-        # def func() -> Annotated[...]
-        if get_origin(return_annotation) is Annotated:
-            for argument in get_args(return_annotation):
-                if isinstance(argument, Name):
-                    names.append((argument.name, get_args(return_annotation)[0]))
-
-        # def func() -> tuple[...]: OR def func() -> A | B:
-        elif get_origin(return_annotation) is tuple or is_union(return_annotation):
-            for argument in get_args(return_annotation):
-                if get_origin(argument) in [Annotated, tuple]:
-                    names += Signal._collect_signal_names(argument)
-                elif argument not in [type(None), None]:
-                    names = [(default_name, return_annotation)]
-
-        # def func() -> type:
-        elif return_annotation and (return_annotation is not inspect.Signature.empty):
-            names = [(default_name, return_annotation)]
-
-        return names
-
-
-class Edge(BaseModel):
-    """
-    Directed connection between an output slot a node and an input slot in another node
-    """
-
-    source_node: str
-    source_signal: str
-    target_node: str
-    target_slot: str | int | None = None
-    """
-    - For kwargs, target_slot is the name of the kwarg that the value is passed to.
-    - For positional arguments, target_slot is an integer that indicates the index of the arg
-    - For scalar arguments, target slot is None 
-    """
-    required: bool = True
-
 
 _PROCESS_METHOD_SENTINEL = "__is_process_method__"
 _GENERATOR_METHOD_SENTINEL = "__is_generator_method__"

--- a/packages/noob/src/noob/node/gather.py
+++ b/packages/noob/src/noob/node/gather.py
@@ -6,8 +6,8 @@ from typing import Any, Generic, TypeVar, cast
 
 from pydantic import PrivateAttr
 
+from noob.edge import Slot
 from noob.event import Event, MetaSignal
-from noob.node import Slot
 from noob.node.base import Node
 from noob.node.spec import NodeSpecification
 from noob.types import Epoch

--- a/packages/noob/src/noob/node/return_.py
+++ b/packages/noob/src/noob/node/return_.py
@@ -7,8 +7,9 @@ from typing import Any
 
 from pydantic import PrivateAttr
 
+from noob.edge import Slot
 from noob.event import MetaSignal
-from noob.node.base import Node, Slot
+from noob.node.base import Node
 from noob.node.spec import NodeSpecification
 from noob.types import Epoch, EventMap
 

--- a/packages/noob/src/noob/node/spec.py
+++ b/packages/noob/src/noob/node/spec.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import inspect
-from typing import Annotated, TypeAlias, TypedDict
+import sys
+from typing import Annotated, TypeAlias
 
 from annotated_types import Len
 from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
@@ -10,6 +11,11 @@ from noob.edge import Signal, Slot
 from noob.types import AbsoluteIdentifier, DependencyIdentifier, PythonIdentifier
 from noob.utils import resolve_python_identifier
 from noob.yaml import id_optional_json_schema
+
+if sys.version_info < (3, 12):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 _DependsBasic: TypeAlias = Annotated[
     dict[PythonIdentifier, DependencyIdentifier], Len(min_length=1, max_length=1)

--- a/packages/noob/src/noob/node/spec.py
+++ b/packages/noob/src/noob/node/spec.py
@@ -175,7 +175,7 @@ class NodeSpecification(BaseModel):
             seen.add(signal)
         return val
 
-    @computed_field
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def nodeinfo(self) -> NodeInfo:
         """Information about the node that this spec is for."""

--- a/packages/noob/src/noob/node/spec.py
+++ b/packages/noob/src/noob/node/spec.py
@@ -1,18 +1,15 @@
 from __future__ import annotations
 
 import inspect
-from functools import cached_property
-from typing import TYPE_CHECKING, Annotated, TypeAlias, TypedDict
+from typing import Annotated, TypeAlias, TypedDict
 
 from annotated_types import Len
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
 
+from noob.edge import Signal, Slot
 from noob.types import AbsoluteIdentifier, DependencyIdentifier, PythonIdentifier
 from noob.utils import resolve_python_identifier
 from noob.yaml import id_optional_json_schema
-
-if TYPE_CHECKING:
-    from noob.node.base import Signal, Slot
 
 _DependsBasic: TypeAlias = Annotated[
     dict[PythonIdentifier, DependencyIdentifier], Len(min_length=1, max_length=1)
@@ -92,6 +89,27 @@ Examples:
 """
 
 
+class NodeInfo(TypedDict):
+    """
+    Metadata about the completed spec given the combination of a node spec and a node class.
+
+    The spec if purely static, the node class is *mostly* static,
+    but some important properties - notably signals and slots -
+    can be dynamic: i.e. the signals or slots of the node depend on the spec.
+
+    This metadata is primarily used in visualization or inspection of tubes, rather than at runtime
+    """
+
+    node_id: str
+    """Node ID whose spec this NodeInfo was computed from"""
+    type: str
+    """fully-qualified module.object name for the node type"""
+    signals: dict[str, Signal]
+    """Signals computed from the spec and node class"""
+    slots: dict[str, Slot]
+    """Slots computed from the spec and node class"""
+
+
 class NodeSpecification(BaseModel):
     """
     Specification for a single processing node within a tube .yaml file.
@@ -151,7 +169,8 @@ class NodeSpecification(BaseModel):
             seen.add(signal)
         return val
 
-    @cached_property
+    @computed_field
+    @property
     def nodeinfo(self) -> NodeInfo:
         """Information about the node that this spec is for."""
         from noob.node.base import Node, WrapClassNode, WrapFuncNode
@@ -170,24 +189,3 @@ class NodeSpecification(BaseModel):
         )
 
     __get_pydantic_json_schema__ = classmethod(id_optional_json_schema)  # type: ignore[var-annotated]
-
-
-class NodeInfo(TypedDict):
-    """
-    Metadata about the completed spec given the combination of a node spec and a node class.
-
-    The spec if purely static, the node class is *mostly* static,
-    but some important properties - notably signals and slots -
-    can be dynamic: i.e. the signals or slots of the node depend on the spec.
-
-    This metadata is primarily used in visualization or inspection of tubes, rather than at runtime
-    """
-
-    node_id: str
-    """Node ID whose spec this NodeInfo was computed from"""
-    type: str
-    """fully-qualified module.object name for the node type"""
-    signals: dict[str, Signal]
-    """Signals computed from the spec and node class"""
-    slots: dict[str, Slot]
-    """Slots computed from the spec and node class"""

--- a/packages/noob/src/noob/node/tube.py
+++ b/packages/noob/src/noob/node/tube.py
@@ -3,9 +3,10 @@ import warnings
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Union
 
+from noob.edge import Slot
 from noob.event import Event
 from noob.exceptions import ExtraInputWarning
-from noob.node.base import Node, Slot
+from noob.node.base import Node
 from noob.node.spec import NodeSpecification
 from noob.types import ConfigSource, Epoch, RunnerContext
 

--- a/packages/noob/src/noob/runner/base.py
+++ b/packages/noob/src/noob/runner/base.py
@@ -17,10 +17,11 @@ from typing import TYPE_CHECKING, Any, ParamSpec, Self, TypeVar, overload
 
 from noob import Tube, init_logger
 from noob.asset import AssetScope
+from noob.edge import Edge
 from noob.event import Event, MetaEvent
 from noob.exceptions import InputMissingError
 from noob.input import InputScope
-from noob.node import Edge, Node, Return
+from noob.node import Node, Return
 from noob.store import EventStore
 from noob.types import Epoch, PythonIdentifier, ReturnNodeType, RunnerContext
 from noob.utils import iscoroutinefunction_partial

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -20,6 +20,7 @@ from pydantic import ValidationError
 from noob import init_logger
 from noob.asset import AssetScope, AssetSpecification
 from noob.config import config
+from noob.edge import Edge, Signal
 from noob.event import Event, MetaEvent
 from noob.exceptions import AlreadyDoneError, EpochCompletedError
 from noob.input import InputCollection
@@ -41,7 +42,7 @@ from noob.network.message import (
     StatusMsg,
     StopMsg,
 )
-from noob.node import Edge, Node, NodeSpecification, Signal
+from noob.node import Node, NodeSpecification
 from noob.scheduler import Scheduler
 from noob.state import State
 from noob.store import EventStore

--- a/packages/noob/src/noob/scheduler.py
+++ b/packages/noob/src/noob/scheduler.py
@@ -10,10 +10,11 @@ from itertools import count
 from typing import Self
 from uuid import uuid4
 
+from noob.edge import Edge
 from noob.event import Event, MetaEvent, MetaEventType, MetaSignal
 from noob.exceptions import AlreadyDoneError, EpochCompletedError, EpochExistsError, NotAddedError
 from noob.logging import init_logger
-from noob.node import Edge, NodeSpecification
+from noob.node import NodeSpecification
 from noob.toposort import GraphItem, NodeSignal, TopoSorter
 from noob.types import Epoch, NodeID, SignalName
 

--- a/packages/noob/src/noob/state.py
+++ b/packages/noob/src/noob/state.py
@@ -7,9 +7,9 @@ from typing import Self, TypeAlias
 from pydantic import BaseModel, Field
 
 from noob.asset import Asset, AssetScope, AssetSpecification
+from noob.edge import Edge
 from noob.event import Event, MetaEvent, MetaSignal
 from noob.input import InputCollection
-from noob.node.base import Edge
 from noob.types import NodeID, PythonIdentifier
 
 if sys.version_info < (3, 12):

--- a/packages/noob/src/noob/store.py
+++ b/packages/noob/src/noob/store.py
@@ -11,9 +11,8 @@ from itertools import count
 from threading import Condition
 from typing import Any, Literal, TypeAlias, overload
 
+from noob.edge import Edge, Signal
 from noob.event import Event, is_event
-from noob.node import Edge
-from noob.node.base import Signal
 from noob.types import Epoch, EventMap, NodeID, SignalName
 
 EventDict: TypeAlias = dict[Epoch, dict[NodeID, dict[SignalName, list[Event]]]]

--- a/packages/noob/src/noob/testing/nodes.py
+++ b/packages/noob/src/noob/testing/nodes.py
@@ -12,8 +12,9 @@ from faker import Faker
 from pydantic import Field
 
 from noob import Name, NodeSpecification, process_method
+from noob.edge import Signal, Slot
 from noob.event import MetaSignal
-from noob.node import Node, Signal, Slot
+from noob.node import Node
 from noob.types import Epoch, EventMap
 
 

--- a/packages/noob/src/noob/toposort.py
+++ b/packages/noob/src/noob/toposort.py
@@ -3,8 +3,9 @@ from collections.abc import Sequence
 from operator import attrgetter
 from typing import Any, TypeAlias
 
+from noob.edge import Edge
 from noob.exceptions import AlreadyDoneError, NotAddedError
-from noob.node import Edge, NodeSpecification
+from noob.node import NodeSpecification
 from noob.types import NodeID, NodeSignal
 
 GraphItem: TypeAlias = NodeID | NodeSignal

--- a/packages/noob/src/noob/tube.py
+++ b/packages/noob/src/noob/tube.py
@@ -20,9 +20,10 @@ from pydantic_core import CoreSchema
 from ruamel.yaml import CommentedMap
 
 from noob.asset import AssetSpecification
+from noob.edge import Edge
 from noob.exceptions import InputMissingError
 from noob.input import InputCollection, InputScope, InputSpecification
-from noob.node import Edge, Node, NodeInfo, NodeSpecification, Return
+from noob.node import Node, NodeInfo, NodeSpecification, Return
 from noob.scheduler import Scheduler
 from noob.state import State
 from noob.types import ConfigSource, NodeSignal, PythonIdentifier
@@ -644,7 +645,12 @@ def _dump_spec(spec: TubeSpecification | Mapping) -> dict:
     if not isinstance(spec, TubeSpecification):
         return dict(spec)
     # dump spec while merging
-    data = spec.model_dump(exclude_unset=True, exclude_defaults=True, by_alias=True)
+    data = spec.model_dump(
+        exclude_unset=True,
+        exclude_defaults=True,
+        by_alias=True,
+        exclude={"nodes": {"__all__": {"nodeinfo"}}},
+    )
     # materialized node specs have `id` fields filled in.
     # treat the keys in the dict as decisive
     for node in data["nodes"].values():

--- a/packages/noob/src/noob/types.py
+++ b/packages/noob/src/noob/types.py
@@ -164,6 +164,12 @@ Picklable = Annotated[
     BeforeValidator(_from_jsonable_pickle),
     WrapSerializer(_to_jsonable_pickle, when_used="json"),
 ]
+TStr = TypeVar("TStr")
+JsonStringable = Annotated[
+    TStr,
+    PlainSerializer(str, when_used="json"),
+]
+"""Generic type that casts the inner type to a string when serializing as JSON"""
 
 # type aliases, mostly for documentation's sake
 NodeID: TypeAlias = Annotated[str, AfterValidator(_is_identifier), AfterValidator(_not_reserved)]

--- a/packages/noob/tests/fixtures/sorter.py
+++ b/packages/noob/tests/fixtures/sorter.py
@@ -1,6 +1,6 @@
 import pytest
 
-from noob.node import Edge
+from noob.edge import Edge
 
 
 @pytest.fixture()

--- a/packages/noob/tests/node/test_signal.py
+++ b/packages/noob/tests/node/test_signal.py
@@ -7,7 +7,7 @@ import pytest
 from faker import Faker
 
 from noob import Name
-from noob.node.base import Signal
+from noob.edge import Signal
 
 
 def one_return(name: str) -> A[str, Name("hey")]:

--- a/packages/noob/tests/node/test_spec.py
+++ b/packages/noob/tests/node/test_spec.py
@@ -1,6 +1,7 @@
 from typing import Any
 
-from noob.node import NodeSpecification, Signal, Slot
+from noob.edge import Signal, Slot
+from noob.node import NodeSpecification
 
 
 def test_nodeinfo():

--- a/packages/noob/tests/node/test_wrap.py
+++ b/packages/noob/tests/node/test_wrap.py
@@ -3,8 +3,9 @@ from typing import Any
 
 import pytest
 
+from noob.edge import Signal
 from noob.node import NodeSpecification
-from noob.node.base import Node, Signal
+from noob.node.base import Node
 
 
 @pytest.mark.parametrize(

--- a/packages/noob/tests/test_scheduler.py
+++ b/packages/noob/tests/test_scheduler.py
@@ -5,9 +5,9 @@ from queue import Empty
 import pytest
 
 from noob import NodeSpecification, SynchronousRunner, Tube
+from noob.edge import Edge
 from noob.event import Event, MetaEventType
 from noob.exceptions import EpochCompletedError
-from noob.node import Edge
 from noob.scheduler import Scheduler
 from noob.toposort import TopoSorter
 from noob.types import Epoch

--- a/packages/noob/tests/test_store.py
+++ b/packages/noob/tests/test_store.py
@@ -2,8 +2,8 @@ from datetime import UTC, datetime
 
 import pytest
 
+from noob.edge import Signal
 from noob.event import Event
-from noob.node import Signal
 from noob.store import EventStore
 from noob.types import Epoch
 

--- a/packages/noob/tests/test_toposort.py
+++ b/packages/noob/tests/test_toposort.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from noob.node import Edge
+from noob.edge import Edge
 from noob.toposort import TopoSorter
 from noob.types import NodeSignal
 


### PR DESCRIPTION
the backlog groweth bigger

Builds on: #211, #212, #213

Previously we just took the spec's word for it and just drew whatever edges existed in it, but that was strictly wrong - nodes have other signals and slots than what the spec might use, and also the spec could be wrong and just making shit up.

so we just forward the node info along with the node and that simplifies things a lot.

also
- more unification of signal and slot: rename `type_` to `annotation`
- mode the edge classes (signal, slot, edge) to their own module for import reasons

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--214.org.readthedocs.build/en/214/

<!-- readthedocs-preview noob end -->