### PR TITLE
Perf: avoiding epoch.__eq__

### DIFF
--- a/packages/noob/src/noob/scheduler.py
+++ b/packages/noob/src/noob/scheduler.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from functools import cached_property
-from itertools import count
 from typing import Self
 from uuid import uuid4
 
@@ -33,7 +32,7 @@ class Scheduler:
     source_nodes: list[NodeID] = field(default_factory=list)
     _logger: logging.Logger = field(default_factory=lambda: init_logger("noob.scheduler"))
 
-    _clock: count = field(default_factory=count)
+    _last_epoch: int = -1
     _epochs: dict[Epoch, TopoSorter] = field(default_factory=dict)
     _subepochs: dict[Epoch, set[Epoch]] = field(default_factory=lambda: defaultdict(set))
     _epoch_log: deque[int] = field(default_factory=lambda: deque(maxlen=100))
@@ -95,19 +94,20 @@ class Scheduler:
                 this_epoch = epoch
             else:
                 raise TypeError("Can only create an epoch from an epoch or integer")
+
+            # only need to check if already run when explicitly setting epoch
+            # otherwise, internal counter keeps us fresh
+            if this_epoch in self._epochs:
+                raise EpochExistsError(f"Epoch {this_epoch} is already scheduled")
+            elif this_epoch in self._epoch_log:
+                raise EpochCompletedError(f"Epoch {this_epoch} has already been completed!")
+
             # ensure that the next iteration of the clock will return the next number
             # if we create epochs out of order
-            self._clock = count(
-                max([this_epoch[0].epoch, *[ep[0].epoch for ep in self._epochs], *self._epoch_log])
-                + 1
-            )
+            self._last_epoch = max(self._last_epoch, this_epoch[0].epoch)
         else:
-            this_epoch = Epoch(next(self._clock))
-
-        if this_epoch in self._epochs:
-            raise EpochExistsError(f"Epoch {this_epoch} is already scheduled")
-        elif this_epoch in self._epoch_log:
-            raise EpochCompletedError(f"Epoch {this_epoch} has already been completed!")
+            self._last_epoch += 1
+            this_epoch = Epoch(self._last_epoch)
 
         graph = self._init_graph(epoch=this_epoch)
         self._epochs[this_epoch] = graph
@@ -250,6 +250,11 @@ class Scheduler:
             return node in self._epochs[epoch].done_nodes
 
     def __getitem__(self, epoch: Epoch | int) -> TopoSorter:
+        # O(1) fast exit - we are given an epoch and we already have it
+        if epoch in self._epochs:
+            return self._epochs[epoch]
+
+        # otherwise, find or create the epoch
         if epoch == -1:
             if len(self._epochs) == 1:
                 return next(iter(self._epochs.values()))
@@ -408,14 +413,14 @@ class Scheduler:
         return previously_completed or active_completed
 
     def end_epoch(self, epoch: Epoch | int | None = None) -> MetaEvent | None:
-        if epoch is None or epoch == -1:
+        if isinstance(epoch, Epoch):
+            ep = epoch
+        elif isinstance(epoch, int):
+            ep = Epoch(epoch)
+        elif epoch is None or epoch == -1:
             if len(self._epochs) == 0:
                 return None
             ep = list(self._epochs)[-1]
-        elif isinstance(epoch, int):
-            ep = Epoch(epoch)
-        elif isinstance(epoch, Epoch):
-            ep = epoch
         else:
             raise TypeError("Can only end an epoch with an integer or Epoch")
         self._logger.debug("Ending epoch %s", ep)

--- a/packages/noob/src/noob/scheduler.py
+++ b/packages/noob/src/noob/scheduler.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from functools import cached_property
-from typing import Self
+from typing import Self, cast
 from uuid import uuid4
 
 from noob.edge import Edge
@@ -252,6 +252,7 @@ class Scheduler:
     def __getitem__(self, epoch: Epoch | int) -> TopoSorter:
         # O(1) fast exit - we are given an epoch and we already have it
         if epoch in self._epochs:
+            epoch = cast(Epoch, epoch)
             return self._epochs[epoch]
 
         # otherwise, find or create the epoch


### PR DESCRIPTION
doing some simple profiling and perf improvements, `Epoch.__eq__` was taking an astonishingly long time, 6-7% of runtime for the kitchen sink with the async runner in 1000 process calls.

<img width="1910" height="1436" alt="Screenshot 2026-05-19 at 7 32 32 PM" src="https://github.com/user-attachments/assets/a67b9b58-b794-4e9d-8b1a-d631bb6831ed" />

turns out that can totally be eliminated in normal runs by just reordering things s.t. we don't need to call `==` when we are given an epoch. comments inline

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--224.org.readthedocs.build/en/224/

<!-- readthedocs-preview noob end -->