### PR TITLE
Perf: cache edges

### DIFF
--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -229,7 +229,7 @@ class Node(BaseModel):
         """Similar to :meth:`.get_signals`, but for slots!"""
         return Slot.from_callable(cls.process, spec)
 
-    @property
+    @functools.cached_property
     def edges(self) -> list[Edge]:
         """
         The dependencies this node has declared, express as edges between


### PR DESCRIPTION
computing edges is fast, but it gets called a lot, e.g. in 1000 iterations of the kitchen sink, it's called 15,924 times, which is 0.549 cumulative seconds (2.58% of total time)

so... just cache it. this shouldn't change during the lifespan of a node.

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--226.org.readthedocs.build/en/226/

<!-- readthedocs-preview noob end -->