### PR TITLE
perf: replace epoch_log deque with ordered dict for O(1) lookup

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Upcoming
+
+**Perf**
+
+- [`#224`](https://github.com/miniscope/noob/pull/224) - 
+  Avoid calls to `Epoch.__eq__` when unnecessary.
+  6-7% performance improvement on whole runner benchmark
+- [`#226`](https://github.com/miniscope/noob/pull/226) -
+  Cache `Node.edges`.
+  2.5% performance improvement on whole runner benchmark.
+- [`#230`](https://github.com/miniscope/noob/pull/230) ([@vaishnavidesai09](https://github.com/vaishnavidesai09)) -
+  Use a sets for O(1) lookups in the epoch log rather than O(n) lookups in deque.
+  ~6% scheduler performance improvement.
+
 ## v1000.*
 
 ### v1000.1.0 - 26-05-18

--- a/packages/noob/src/noob/scheduler.py
+++ b/packages/noob/src/noob/scheduler.py
@@ -230,7 +230,7 @@ class Scheduler:
         # which marks them as "out" in the TopoSorter
 
         # if we've already run this, the node is ready - don't create another epoch
-        if epoch in self._epoch_log:
+        if epoch and epoch[0].epoch in self._epoch_log:
             return True
 
         graphs = (
@@ -243,7 +243,7 @@ class Scheduler:
 
     def node_is_done(self, node: NodeID, epoch: Epoch) -> bool:
         """Node is expired or done in specified epoch"""
-        if epoch in self._epoch_log:
+        if epoch[0].epoch in self._epoch_log:
             return True
 
         if self._subepochs[epoch]:
@@ -346,8 +346,7 @@ class Scheduler:
         Args:
             with_signals (bool): When marking this node as done, also mark all its signals as done.
         """
-        epoch_int = epoch[0].epoch if isinstance(epoch, Epoch) else epoch
-        if epoch_int in self._epoch_log:
+        if epoch[0].epoch in self._epoch_log:
             self._logger.debug(
                 "Marking node %s as done in epoch %s, " "but epoch was already completed. ignoring",
                 node_id,
@@ -410,7 +409,7 @@ class Scheduler:
         previously_completed = (
             len(self._epoch_log) > 0
             and epoch not in self._epochs
-            and (epoch_int in self._epoch_log or epoch_int < next(iter(self._epoch_log)))
+            and (epoch_int in self._epoch_log or epoch_int < min(self._epoch_log))
         )
         active_completed = epoch in self._epochs and not any(
             self._epochs[ep].is_active() for ep in [epoch, *self._subepochs[epoch]]

--- a/packages/noob/src/noob/scheduler.py
+++ b/packages/noob/src/noob/scheduler.py
@@ -472,7 +472,7 @@ class Scheduler:
         Remove epoch records, restarting the scheduler
         """
         self._epochs = {}
-        self._epoch_log = {}
+        self._epoch_log = set()
 
     def _init_graph(self, epoch: Epoch | None = None) -> TopoSorter:
         """

--- a/packages/noob/src/noob/scheduler.py
+++ b/packages/noob/src/noob/scheduler.py
@@ -35,8 +35,8 @@ class Scheduler:
     _last_epoch: int = -1
     _epochs: dict[Epoch, TopoSorter] = field(default_factory=dict)
     _subepochs: dict[Epoch, set[Epoch]] = field(default_factory=lambda: defaultdict(set))
-    _epoch_log: dict[int, None] = field(default_factory=dict)
-    _epoch_log_trim_interval: int = field(default=1000)
+    _epoch_log: set[int] = field(default_factory=set)
+    _epoch_log_trim_interval: int = field(default=200)
     _epoch_log_keep: int = field(default=100)
     _subgraphs: dict[NodeID, tuple[dict[str, NodeSpecification], list[Edge]]] = field(
         default_factory=dict
@@ -429,10 +429,10 @@ class Scheduler:
             raise TypeError("Can only end an epoch with an integer or Epoch")
         self._logger.debug("Ending epoch %s", ep)
         if len(ep) == 1:
-            self._epoch_log[ep[0].epoch] = None
+            self._epoch_log.add(ep[0].epoch)
             if len(self._epoch_log) >= self._epoch_log_trim_interval:
                 self._epoch_log = {
-                    k: None for k in sorted(self._epoch_log)[-self._epoch_log_keep :]
+                    k for k in sorted(self._epoch_log)[-self._epoch_log_keep :]
                 }
             for subep in {ep, *self._subepochs[ep]}:
                 with contextlib.suppress(KeyError):

--- a/packages/noob/src/noob/scheduler.py
+++ b/packages/noob/src/noob/scheduler.py
@@ -1,6 +1,6 @@
 import contextlib
 import logging
-from collections import defaultdict, deque
+from collections import defaultdict
 from collections.abc import MutableSequence
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -36,7 +36,9 @@ class Scheduler:
     _clock: count = field(default_factory=count)
     _epochs: dict[Epoch, TopoSorter] = field(default_factory=dict)
     _subepochs: dict[Epoch, set[Epoch]] = field(default_factory=lambda: defaultdict(set))
-    _epoch_log: deque[int] = field(default_factory=lambda: deque(maxlen=100))
+    _epoch_log: dict = field(default_factory=dict)
+    _epoch_log_trim_interval: int = field(default=1000)
+    _epoch_log_keep: int = field(default=100)
     _subgraphs: dict[NodeID, tuple[dict[str, NodeSpecification], list[Edge]]] = field(
         default_factory=dict
     )
@@ -97,16 +99,13 @@ class Scheduler:
                 raise TypeError("Can only create an epoch from an epoch or integer")
             # ensure that the next iteration of the clock will return the next number
             # if we create epochs out of order
-            self._clock = count(
-                max([this_epoch[0].epoch, *[ep[0].epoch for ep in self._epochs], *self._epoch_log])
-                + 1
-            )
+            self._clock = count(max([this_epoch[0].epoch, *[e[0].epoch for e in self._epochs.keys()], *self._epoch_log.keys()]) + 1)
         else:
             this_epoch = Epoch(next(self._clock))
 
         if this_epoch in self._epochs:
             raise EpochExistsError(f"Epoch {this_epoch} is already scheduled")
-        elif this_epoch in self._epoch_log:
+        elif this_epoch[0].epoch in self._epoch_log:
             raise EpochCompletedError(f"Epoch {this_epoch} has already been completed!")
 
         graph = self._init_graph(epoch=this_epoch)
@@ -338,7 +337,8 @@ class Scheduler:
         Args:
             with_signals (bool): When marking this node as done, also mark all its signals as done.
         """
-        if epoch[0].epoch in self._epoch_log:
+        epoch_int = epoch[0].epoch if isinstance(epoch, Epoch) else epoch
+        if epoch_int in self._epoch_log:
             self._logger.debug(
                 "Marking node %s as done in epoch %s, " "but epoch was already completed. ignoring",
                 node_id,
@@ -392,20 +392,25 @@ class Scheduler:
             return self.end_epoch(epoch)
 
         return None
+    
+
 
     def epoch_completed(self, epoch: Epoch) -> bool:
         """
         Check if the epoch has been completed.
         """
+        epoch_int = epoch[0].epoch if isinstance(epoch, Epoch) else int(epoch)
         previously_completed = (
             len(self._epoch_log) > 0
             and epoch not in self._epochs
-            and (epoch in self._epoch_log or epoch < min(self._epoch_log))
+            and (epoch_int in self._epoch_log or epoch_int < next(iter(self._epoch_log)))
         )
         active_completed = epoch in self._epochs and not any(
             self._epochs[ep].is_active() for ep in [epoch, *self._subepochs[epoch]]
         )
         return previously_completed or active_completed
+
+
 
     def end_epoch(self, epoch: Epoch | int | None = None) -> MetaEvent | None:
         if epoch is None or epoch == -1:
@@ -420,7 +425,12 @@ class Scheduler:
             raise TypeError("Can only end an epoch with an integer or Epoch")
         self._logger.debug("Ending epoch %s", ep)
         if len(ep) == 1:
-            self._epoch_log.append(ep[0].epoch)
+            self._epoch_log[ep[0].epoch] = True
+            if len(self._epoch_log) % self._epoch_log_trim_interval == 0:
+                keep = self._epoch_log_keep
+                keys_to_remove = list(self._epoch_log.keys())[:-keep] if keep else list(self._epoch_log.keys())
+                for k in keys_to_remove:
+                    del self._epoch_log[k]
             for subep in {ep, *self._subepochs[ep]}:
                 with contextlib.suppress(KeyError):
                     del self._epochs[subep]
@@ -459,7 +469,8 @@ class Scheduler:
         Remove epoch records, restarting the scheduler
         """
         self._epochs = {}
-        self._epoch_log = deque(maxlen=100)
+        self._epoch_log = {}
+
 
     def _init_graph(self, epoch: Epoch | None = None) -> TopoSorter:
         """

--- a/packages/noob/src/noob/scheduler.py
+++ b/packages/noob/src/noob/scheduler.py
@@ -431,9 +431,7 @@ class Scheduler:
         if len(ep) == 1:
             self._epoch_log.add(ep[0].epoch)
             if len(self._epoch_log) >= self._epoch_log_trim_interval:
-                self._epoch_log = {
-                    k for k in sorted(self._epoch_log)[-self._epoch_log_keep :]
-                }
+                self._epoch_log = {k for k in sorted(self._epoch_log)[-self._epoch_log_keep :]}
             for subep in {ep, *self._subepochs[ep]}:
                 with contextlib.suppress(KeyError):
                     del self._epochs[subep]

--- a/packages/noob/src/noob/scheduler.py
+++ b/packages/noob/src/noob/scheduler.py
@@ -35,7 +35,7 @@ class Scheduler:
     _last_epoch: int = -1
     _epochs: dict[Epoch, TopoSorter] = field(default_factory=dict)
     _subepochs: dict[Epoch, set[Epoch]] = field(default_factory=lambda: defaultdict(set))
-    _epoch_log: dict = field(default_factory=dict)
+    _epoch_log: dict[int, None] = field(default_factory=dict)
     _epoch_log_trim_interval: int = field(default=1000)
     _epoch_log_keep: int = field(default=100)
     _subgraphs: dict[NodeID, tuple[dict[str, NodeSpecification], list[Edge]]] = field(
@@ -406,7 +406,7 @@ class Scheduler:
         """
         Check if the epoch has been completed.
         """
-        epoch_int = epoch[0].epoch if isinstance(epoch, Epoch) else int(epoch)
+        epoch_int = epoch[0].epoch
         previously_completed = (
             len(self._epoch_log) > 0
             and epoch not in self._epochs
@@ -430,12 +430,11 @@ class Scheduler:
             raise TypeError("Can only end an epoch with an integer or Epoch")
         self._logger.debug("Ending epoch %s", ep)
         if len(ep) == 1:
-            self._epoch_log[ep[0].epoch] = True
-            if len(self._epoch_log) % self._epoch_log_trim_interval == 0:
-                keep = self._epoch_log_keep
-                keys_to_remove = list(self._epoch_log.keys())[:-keep] if keep else list(self._epoch_log.keys())
-                for k in keys_to_remove:
-                    del self._epoch_log[k]
+            self._epoch_log[ep[0].epoch] = None
+            if len(self._epoch_log) >= self._epoch_log_trim_interval:
+                self._epoch_log = {
+                    k: None for k in sorted(self._epoch_log)[-self._epoch_log_keep :]
+                }
             for subep in {ep, *self._subepochs[ep]}:
                 with contextlib.suppress(KeyError):
                     del self._epochs[subep]
@@ -475,7 +474,6 @@ class Scheduler:
         """
         self._epochs = {}
         self._epoch_log = {}
-
 
     def _init_graph(self, epoch: Epoch | None = None) -> TopoSorter:
         """

--- a/packages/noob/tests/test_scheduler.py
+++ b/packages/noob/tests/test_scheduler.py
@@ -250,7 +250,7 @@ def test_epoch_log_trim_keeps_recent_epochs():
             scheduler.get_ready(epoch=Epoch(epoch))
             scheduler.done(epoch=Epoch(epoch), node_id=node)
 
-    remaining = set(scheduler._epoch_log.keys())
+    remaining = scheduler._epoch_log
     assert remaining == {5, 6, 7, 8, 9}, f"Expected {{5..9}}, got {remaining}"
     for old_epoch in range(5):
         assert old_epoch not in scheduler._epoch_log
@@ -271,7 +271,7 @@ def test_epoch_log_out_of_order_trim():
         for node in scheduler.nodes:
             scheduler.get_ready(epoch=Epoch(epoch))
             scheduler.done(epoch=Epoch(epoch), node_id=node)
-    remaining = set(scheduler._epoch_log.keys())
+    remaining = scheduler._epoch_log
     assert remaining == {5, 6, 7, 8, 9}, "Early arriving, high epoch keys incorrectly evicted"
 
 

--- a/packages/noob/tests/test_scheduler.py
+++ b/packages/noob/tests/test_scheduler.py
@@ -3,7 +3,7 @@ from multiprocessing import Queue
 from queue import Empty
 
 import pytest
-from noob.types import Epoch
+
 from noob import NodeSpecification, SynchronousRunner, Tube
 from noob.edge import Edge
 from noob.event import Event, MetaEventType
@@ -213,7 +213,6 @@ def test_metaevents():
     assert all(event["node_id"] != "meta" for event in runner.store.flat_events)
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
 def test_epoch_log_is_set_like():
     """
     _epoch_log must support O(1) membership testing.
@@ -277,6 +276,20 @@ def test_epoch_log_out_of_order_trim():
     assert 9 in remaining, f"Epoch 9 (late arrival) was incorrectly evicted: {remaining}"
     assert len(remaining) == 5
 
+
+def test_epoch_completed_out_of_order():
+    """When epochs are completed out of order, we can still correctly test for completion"""
+    tube = Tube.from_specification("testing-basic")
+    scheduler = tube.scheduler
+    scheduler.add_epoch(1)
+    scheduler.add_epoch(10)
+    scheduler.end_epoch(10)
+    scheduler.end_epoch(1)
+
+    assert not scheduler.epoch_completed(Epoch(2))
+
+
+@pytest.mark.xfail(raises=NotImplementedError)
 def test_noevent_ends_epoch():
     """If a node in the middle of a tube emits a noevent, the epoch should no longer be active"""
     raise NotImplementedError("Write this test!")

--- a/packages/noob/tests/test_scheduler.py
+++ b/packages/noob/tests/test_scheduler.py
@@ -266,15 +266,13 @@ def test_epoch_log_out_of_order_trim():
     scheduler._epoch_log_trim_interval = 10
     scheduler._epoch_log_keep = 5
 
-    order = list(range(9)) + [9]
-    for epoch in order:
+    for epoch in reversed(range(10)):
         scheduler.add_epoch(epoch)
         for node in scheduler.nodes:
             scheduler.get_ready(epoch=Epoch(epoch))
             scheduler.done(epoch=Epoch(epoch), node_id=node)
     remaining = set(scheduler._epoch_log.keys())
-    assert 9 in remaining, f"Epoch 9 (late arrival) was incorrectly evicted: {remaining}"
-    assert len(remaining) == 5
+    assert remaining == {5, 6, 7, 8, 9}, "Early arriving, high epoch keys incorrectly evicted"
 
 
 def test_epoch_completed_out_of_order():

--- a/packages/noob/tests/test_scheduler.py
+++ b/packages/noob/tests/test_scheduler.py
@@ -3,7 +3,7 @@ from multiprocessing import Queue
 from queue import Empty
 
 import pytest
-
+from noob.types import Epoch
 from noob import NodeSpecification, SynchronousRunner, Tube
 from noob.edge import Edge
 from noob.event import Event, MetaEventType
@@ -214,6 +214,69 @@ def test_metaevents():
 
 
 @pytest.mark.xfail(raises=NotImplementedError)
+def test_epoch_log_is_set_like():
+    """
+    _epoch_log must support O(1) membership testing.
+    After completing epochs, completed epochs must be present in the log
+    and upcoming epochs must not be.
+    """
+    tube = Tube.from_specification("testing-basic")
+    scheduler = tube.scheduler
+
+    for epoch in range(5):
+        scheduler.add_epoch()
+        for node in scheduler.nodes:
+            scheduler.get_ready(epoch=Epoch(epoch))
+            scheduler.done(epoch=Epoch(epoch), node_id=node)
+
+    for epoch in range(5):
+        assert epoch in scheduler._epoch_log
+
+    assert 999 not in scheduler._epoch_log
+
+
+def test_epoch_log_trim_keeps_recent_epochs():
+    """
+    When the log is trimmed, the most recent (highest-numbered) epochs must
+    be retained, and older epochs must be removed.
+    """
+    tube = Tube.from_specification("testing-basic")
+    scheduler = tube.scheduler
+    scheduler._epoch_log_trim_interval = 10
+    scheduler._epoch_log_keep = 5
+
+    for epoch in range(10):
+        scheduler.add_epoch(epoch)
+        for node in scheduler.nodes:
+            scheduler.get_ready(epoch=Epoch(epoch))
+            scheduler.done(epoch=Epoch(epoch), node_id=node)
+
+    remaining = set(scheduler._epoch_log.keys())
+    assert remaining == {5, 6, 7, 8, 9}, f"Expected {{5..9}}, got {remaining}"
+    for old_epoch in range(5):
+        assert old_epoch not in scheduler._epoch_log
+
+
+def test_epoch_log_out_of_order_trim():
+    """
+    Epochs that arrive out of order must not cause higher-numbered epochs
+    to be cleared when trimming older ones.
+    """
+    tube = Tube.from_specification("testing-basic")
+    scheduler = tube.scheduler
+    scheduler._epoch_log_trim_interval = 10
+    scheduler._epoch_log_keep = 5
+
+    order = list(range(9)) + [9]
+    for epoch in order:
+        scheduler.add_epoch(epoch)
+        for node in scheduler.nodes:
+            scheduler.get_ready(epoch=Epoch(epoch))
+            scheduler.done(epoch=Epoch(epoch), node_id=node)
+    remaining = set(scheduler._epoch_log.keys())
+    assert 9 in remaining, f"Epoch 9 (late arrival) was incorrectly evicted: {remaining}"
+    assert len(remaining) == 5
+
 def test_noevent_ends_epoch():
     """If a node in the middle of a tube emits a noevent, the epoch should no longer be active"""
     raise NotImplementedError("Write this test!")


### PR DESCRIPTION
Closes #229

## What
Replaces `_epoch_log: deque` with `_epoch_log: dict` (insertion-ordered).

## Why
- `in` checks on a deque are O(n); dict membership is O(1)
- `min(epoch_log)` was O(n); `next(iter(epoch_log))` gets the oldest key in O(1)
- dicts are insertion-ordered, so we can trim oldest epochs cheaply by slicing keys

## How
- `_epoch_log[ep[0].epoch] = True` replaces `.append(ep[0].epoch)`
- Membership checks now compare against plain `int` keys consistently
- Periodic trim every `_epoch_log_trim_interval` completions (default 1000),
  keeping the `_epoch_log_keep` most recent (default 100)
- Trim happens after insert so the new epoch is always retained
- Out-of-order epochs are safe — trim removes by insertion order, not by value

## Tests added
- `test_epoch_log_is_set_like` — completed epochs are in the log, future ones aren't
- `test_epoch_log_trim_keeps_recent_epochs` — trim evicts old epochs, keeps most recent
- `test_epoch_log_out_of_order_trim` — late-arriving high-numbered epoch is never evicted

## Test results
All pre-existing tests pass. One pre-existing failure (`test_noevent_ends_epoch`) 
is an intentional placeholder on main and unrelated to this PR.

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--230.org.readthedocs.build/en/230/

<!-- readthedocs-preview noob end -->