### PR TITLE
Represent assets in viewer, fix prefix nesting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,10 @@ noob_config.yml
 prof/
 packages/**/pylock.toml
 packages/noob/src/noob/_js
+rolldown-runtime-*
+elkjs-*.js
+react-*.js
+reactflow-*.js
+elkjs-*.map
+react-*.map
+reactflow-*.map

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,17 @@
   Use a sets for O(1) lookups in the epoch log rather than O(n) lookups in deque.
   ~6% scheduler performance improvement.
 
+**Add**
+
+- [`#233`](https://github.com/miniscope/noob/pull/233) -
+  Preliminary representation of assets as nodes in JS viewer
+
+**Fix**
+
+- [`#233`](https://github.com/miniscope/noob/pull/233) -
+  Correctly handle nexted prefixes in JS viewer
+
+
 ## v1000.*
 
 ### v1000.1.0 - 26-05-18

--- a/js/src/tube.tsx
+++ b/js/src/tube.tsx
@@ -4,10 +4,12 @@
  */
 
 import type {
+  AssetSpecification,
   ElkNode as ElkNodeType,
   GroupNode,
   Handle,
   Handles,
+  InputSpecification,
   NodeUnion,
   NoobNode,
   TitleNode,
@@ -23,29 +25,12 @@ export function tubeToFlow(tube: TubeSpecification): [Edge[], NodeUnion[]] {
   const edges = getEdges(tube.nodes);
   let nodes = getNodes(tube.nodes);
   nodes = [_titleNode(tube.noob_id, tube.description ?? ""), ...nodes];
-  // TODO: Dedicated representation of inputs
+
   if (tube.input && Object.keys(tube.input).length !== 0) {
-    nodes = [
-      ...nodes,
-      {
-        id: "input",
-        position: { x: 0, y: 0 },
-        type: "elk",
-        data: {
-          label: "input",
-          nodeType: "input",
-          targetHandles: [],
-          sourceHandles: Object.values(tube.input).map((i) => {
-            return {
-              id: `input.signals.${i.id}`,
-              label: i.id,
-              key: `input.signals.${i.id}`,
-              required: true,
-            };
-          }),
-        },
-      },
-    ];
+    nodes = [...nodes, _inputNode(tube.input)];
+  }
+  if (tube.assets && Object.keys(tube.assets).length !== 0) {
+    nodes = [...nodes, _assetNode(tube.assets)];
   }
   return [edges, nodes];
 }
@@ -148,7 +133,7 @@ function getNodes(nodes: Record<string, NoobNode>): NodeUnion[] {
 function getNode(node: NoobNode, prefix?: string): NodeUnion[] {
   // Create handle description for node and then filter to unique entries
   if (isTubeNode(node)) {
-    return getTubeNode(node);
+    return getTubeNode(node, prefix);
   } else {
     return getGenericNode(node, prefix);
   }
@@ -176,15 +161,17 @@ function getGenericNode(node: NoobNode, prefix?: string): ElkNodeType[] {
  *
  * Renders inputs and the return node as handles on the border of an outer grouping node.
  */
-function getTubeNode(node: TubeNode): NodeUnion[] {
+function getTubeNode(node: TubeNode, prefix?: string): NodeUnion[] {
   // Make the outer grouping node
+  const newPrefix = prefix ? `${prefix}.${node.id}` : node.id;
+
   const innerTube = node.params.tube;
   const targetHandles = innerTube.input
     ? Object.values(innerTube.input).map<Handle>((input) => {
         return {
-          id: `${node.id}.slots.${input.id}`,
+          id: `${newPrefix}.slots.${input.id}`,
           label: input.id,
-          key: `${node.id}.slots.${input.id}`,
+          key: `${newPrefix}.slots.${input.id}`,
           required: true,
         };
       })
@@ -203,9 +190,9 @@ function getTubeNode(node: TubeNode): NodeUnion[] {
       ? Array.from(returnNode.depends).map<Handle>((slotsig) => {
           const slot = Object.keys(slotsig)[0];
           return {
-            id: `${node.id}.signals.${slot}`,
+            id: `${newPrefix}.signals.${slot}`,
             label: slot,
-            key: `${node.id}.signals.${slot}`,
+            key: `${newPrefix}.signals.${slot}`,
             required: false, // return node slots are never really required, special case.
           };
         })
@@ -213,7 +200,7 @@ function getTubeNode(node: TubeNode): NodeUnion[] {
   }
 
   const groupNode = {
-    id: node.id,
+    id: newPrefix,
     type: "group",
     data: {
       label: node.id,
@@ -222,18 +209,21 @@ function getTubeNode(node: TubeNode): NodeUnion[] {
       targetHandles,
     },
     position: { x: 0, y: 0 },
-    key: node.id,
+    key: newPrefix,
   } as GroupNode;
 
   // Then the children that go within it
   let childNodes = Object.values(innerTube.nodes)
     .filter((child) => child.type !== "return")
-    .flatMap<NodeUnion>((child) => getNode(child, node.id));
+    .flatMap<NodeUnion>((child) => getNode(child, newPrefix));
+  if (innerTube.assets && Object.keys(innerTube.assets).length !== 0) {
+    childNodes = [...childNodes, _assetNode(innerTube.assets, newPrefix)];
+  }
   childNodes = childNodes.map((child) => {
     return {
       ...child,
       extent: "parent",
-      parentId: node.id,
+      parentId: newPrefix,
     };
   });
   return [groupNode, ...childNodes];
@@ -282,6 +272,57 @@ function _titleNode(title: string, description: string): TitleNode {
       targetHandles: [],
     },
     type: "title",
+  };
+}
+
+// TODO: Dedicated representation of inputs
+function _inputNode(input: Record<string, InputSpecification>): ElkNodeType {
+  return {
+    id: "input",
+    position: { x: 0, y: 0 },
+    type: "elk",
+    data: {
+      label: "input",
+      nodeType: "input",
+      targetHandles: [],
+      sourceHandles: Object.values(input).map((i) => {
+        return {
+          id: `input.signals.${i.id}`,
+          label: i.id,
+          key: `input.signals.${i.id}`,
+          required: true,
+        };
+      }),
+    },
+  };
+}
+
+// TODO: dedicated representation of assets
+function _assetNode(
+  assets: Record<string, AssetSpecification>,
+  prefix?: string,
+): ElkNodeType {
+  return {
+    id: prefix ? `${prefix}.assets` : "assets",
+    position: { x: 0, y: 0 },
+    type: "elk",
+    data: {
+      label: "assets",
+      nodeType: "assets",
+      targetHandles: [],
+      sourceHandles: Object.values(assets).map((i) => {
+        return {
+          id: prefix
+            ? `${prefix}.assets.signals.${i.id}`
+            : `assets.signals.${i.id}`,
+          label: i.id,
+          key: prefix
+            ? `${prefix}.assets.signals.${i.id}`
+            : `assets.signals.${i.id}`,
+          required: true,
+        };
+      }),
+    },
   };
 }
 

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -6,7 +6,8 @@ export interface TubeSpecification {
   noob_version: string;
   description?: string;
   nodes: Record<string, NoobNode>;
-  input?: Record<string, InputSpecification>;
+  input: Record<string, InputSpecification>;
+  assets: Record<string, AssetSpecification>;
 }
 
 export interface NodeInfo {
@@ -29,6 +30,20 @@ const InputScope = {
   process: "process",
 } as const;
 export type InputScope = (typeof InputScope)[keyof typeof InputScope];
+
+export interface AssetSpecification {
+  id: string;
+  type: string;
+  scope: AssetScope;
+  depends?: string;
+}
+
+const AssetScope = {
+  runner: "runner",
+  process: "process",
+  node: "node",
+} as const;
+export type AssetScope = (typeof AssetScope)[keyof typeof AssetScope];
 
 export interface NoobNode {
   id: string;

--- a/js/src/useLayoutNodes.tsx
+++ b/js/src/useLayoutNodes.tsx
@@ -27,11 +27,11 @@ const layoutOptions = {
   "elk.layered.nodePlacement.bk.edgeStraightening": "NONE",
   "elk.layered.nodePlacement.bk.fixedAlignment": "BALANCED",
   "elk.layered.crossingMinimization.strategy": "MEDIAN_LAYER_SWEEP",
+  "elk.layered.considerModelOrder.crossingCounterPortInfluence": "0.001",
   "elk.nodeSize.constraints": "NODE_LABELS PORT_LABELS PORTS",
   "elk.nodeLabels.placement": "INSIDE H_CENTER V_CENTER",
   "elk.nodeSize.options": "COMPUTE_PADDING",
   "elk.portConstraints": "FIXED_SIDE",
-  "elk.layered.considerModelOrder.crossingCounterPortInfluence": "0.001",
 };
 
 const elk = new ELK();
@@ -45,9 +45,14 @@ export const getLayoutedNodes = async (
   nodes: NodeUnion[],
   edges: Edge[],
 ): Promise<NodeUnion[]> => {
+  const aspectRatio = window.screen.width / window.screen.height;
+  const layoutOpts = {
+    ...layoutOptions,
+    "elk.aspectRatio": String(aspectRatio),
+  };
   const graph = {
     id: "root",
-    layoutOptions,
+    layoutOptions: layoutOpts,
     children: nodes
       .filter((n) => n.parentId === undefined)
       .map((n) => nodeToElk(n, nodes)),
@@ -59,7 +64,7 @@ export const getLayoutedNodes = async (
   };
 
   const layoutedGraph = await elk.layout(graph, {
-    layoutOptions: layoutOptions,
+    layoutOptions: layoutOpts,
   });
   const flatChildren = flattenChildren(layoutedGraph);
 
@@ -163,6 +168,9 @@ function nodeToElk(n: NodeUnion, nodes: NodeUnion[]): PropertiedElkNode {
     // we are also passing the id, so we can also handle edges without a sourceHandle or targetHandle option
     ports: [...targetPorts, ...sourcePorts],
     children: childNodes,
+    ...(childNodes.length != 0 && {
+      layoutOptions: { "elk.layered.wrapping.strategy": "OFF" },
+    }),
   };
 }
 

--- a/js/tests/data/tubes.ts
+++ b/js/tests/data/tubes.ts
@@ -13,6 +13,7 @@ export const recursiveTube: TubeSpecification = {
     child_start: { id: "child_start", type: "int", scope: "tube" },
     child_multiply: { id: "child_multiply", type: "int", scope: "process" },
   },
+  assets: {},
   nodes: {
     a: {
       type: "noob.testing.count_source",


### PR DESCRIPTION
Working on merging some of the mio changes - 

super simple change, just adding a representation for assets in the viewer, and fixing prefixed nesting of ids

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--233.org.readthedocs.build/en/233/

<!-- readthedocs-preview noob end -->