### PR TITLE
Input improvements: optional inputs, inputs to control node enabledness, etc.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,12 +6,24 @@
 
 - [`#233`](https://github.com/miniscope/noob/pull/233) -
   Preliminary representation of assets as nodes in JS viewer
+- [`#234`](https://github.com/miniscope/noob/pull/234) - 
+  Inputs can be `optional` and have a `default`. 
+  These defaults have to be basic yaml types at the moment,
+  more elaborate types are still TODO.
+- [`#234`](https://github.com/miniscope/noob/pull/234) -
+  Nodes can use a tube-scoped `input` to control their enabledness
+- [`#234`](https://github.com/miniscope/noob/pull/234) -
+  The {class}`~noob.input.InputCollection` is now passed in the dependency-injected
+  {class}`~noob.types.RunnerContext`
 - [`#237`](https://github.com/miniscope/noob/pull/237) - 
   {class}`~noob.node.Node`s now have an {attr}`~noob.node.Node.logger` property 
   that lazily instantiates a logger, if accessed.
 
 **Changed**
 
+- [`#234`](https://github.com/miniscope/noob/pull/234) -
+  The `type` of an input can be an arbitrary python type expression instead of an absolute identifier.
+  These are still unused, but they will be used for static type checking in the future.
 - [`#235`](https://github.com/miniscope/noob/pull/235/) -
   Assets (and other specifications) now include their `id` when being dumped to json
 
@@ -19,6 +31,12 @@
 
 - [`#233`](https://github.com/miniscope/noob/pull/233) -
   Correctly handle nexted prefixes in JS viewer
+- [`#234`](https://github.com/miniscope/noob/pull/234) -
+  {class}`.node.Tube` nodes now correctly accept params in their specs
+  and forward them and other inputs to the {class}`~noob.tube.Tube` they wrap.
+- [`#234`](https://github.com/miniscope/noob/pull/234) -
+  The {class}`.ZMQRunner` 's {class}`.zmq.node.NodeRunner` class now correctly injects
+  a requested {class}`~noob.types.RunnerContext`
 - [`#236`](https://github.com/miniscope/noob/pull/236) -
   `context: recursive` when loading a tube specification actually recurses more than two levels
 - [`#236`](https://github.com/miniscope/noob/pull/236) -
@@ -42,31 +60,6 @@
 - [`#232`](https://github.com/miniscope/noob/pull/232) -
   Use a snowflake-like identifier for event IDs rather than UUIDs,
   add helpers for consistently making events.
-
-**Added**
-
-- [`#234`](https://github.com/miniscope/noob/pull/234) - 
-  Inputs can be `optional` and have a `default`. 
-  These defaults have to be basic yaml types at the moment,
-  more elaborate types are still TODO.
-- [`#234`](https://github.com/miniscope/noob/pull/234) -
-  Nodes can use a tube-scoped `input` to control their enabledness
-- [`#234`](https://github.com/miniscope/noob/pull/234) -
-  The {class}`~noob.input.InputCollection` is now passed in the dependency-injected
-  {class}`~noob.types.RunnerContext`
-
-**Fixed**
-- [`#234`](https://github.com/miniscope/noob/pull/234) -
-  {class}`.node.Tube` nodes now correctly accept params in their specs
-  and forward them and other inputs to the {class}`~noob.tube.Tube` they wrap.
-- [`#234`](https://github.com/miniscope/noob/pull/234) -
-  The {class}`.ZMQRunner` 's {class}`.zmq.node.NodeRunner` class now correctly injects
-  a requested {class}`~noob.types.RunnerContext`
-
-**Changed**
-- [`#234`](https://github.com/miniscope/noob/pull/234) -
-  The `type` of an input can be an arbitrary python type expression instead of an absolute identifier.
-  These are still unused, but they will be used for static type checking in the future.
 
 ## v1000.*
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,6 +43,31 @@
   Use a snowflake-like identifier for event IDs rather than UUIDs,
   add helpers for consistently making events.
 
+**Added**
+
+- [`#234`](https://github.com/miniscope/noob/pull/234) - 
+  Inputs can be `optional` and have a `default`. 
+  These defaults have to be basic yaml types at the moment,
+  more elaborate types are still TODO.
+- [`#234`](https://github.com/miniscope/noob/pull/234) -
+  Nodes can use a tube-scoped `input` to control their enabledness
+- [`#234`](https://github.com/miniscope/noob/pull/234) -
+  The {class}`~noob.input.InputCollection` is now passed in the dependency-injected
+  {class}`~noob.types.RunnerContext`
+
+**Fixed**
+- [`#234`](https://github.com/miniscope/noob/pull/234) -
+  {class}`.node.Tube` nodes now correctly accept params in their specs
+  and forward them and other inputs to the {class}`~noob.tube.Tube` they wrap.
+- [`#234`](https://github.com/miniscope/noob/pull/234) -
+  The {class}`.ZMQRunner` 's {class}`.zmq.node.NodeRunner` class now correctly injects
+  a requested {class}`~noob.types.RunnerContext`
+
+**Changed**
+- [`#234`](https://github.com/miniscope/noob/pull/234) -
+  The `type` of an input can be an arbitrary python type expression instead of an absolute identifier.
+  These are still unused, but they will be used for static type checking in the future.
+
 ## v1000.*
 
 ### v1000.1.0 - 26-05-18

--- a/packages/noob/src/noob/input.py
+++ b/packages/noob/src/noob/input.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 from noob.edge import Edge
 from noob.exceptions import ExtraInputWarning, InputMissingError
-from noob.types import AbsoluteIdentifier, PythonIdentifier
+from noob.types import PythonIdentifier
 from noob.yaml import id_optional_json_schema
 
 
@@ -39,7 +39,7 @@ class InputSpecification(BaseModel):
     """
 
     id: PythonIdentifier
-    type_: AbsoluteIdentifier = Field(..., alias="type")
+    type_: str = Field(..., alias="type")
     scope: InputScope = InputScope.tube
     default: Any | None = None
     description: str | None = None

--- a/packages/noob/src/noob/input.py
+++ b/packages/noob/src/noob/input.py
@@ -44,6 +44,7 @@ class InputSpecification(BaseModel):
     default: Any | None = None
     description: str | None = None
     """An optional description of the input value"""
+    required: bool = True
 
     model_config = ConfigDict(extra="forbid")
 
@@ -92,7 +93,14 @@ class InputCollection(BaseModel):
         if input is None:
             input = {}
 
-        return self.chain.new_child(input)[key]
+        try:
+            return self.chain.new_child(input)[key]
+        except KeyError as e:
+            # try and get default if not required
+            for specs in self.specs.values():
+                if key in specs and not specs[key].required:
+                    return specs[key].default
+            raise e
 
     @overload
     def get_node_params(self, params: dict) -> dict: ...
@@ -190,7 +198,7 @@ class InputCollection(BaseModel):
         chain = self.chain.new_child(input)
 
         for spec in self.specs[scope].values():
-            if spec.id not in chain:
+            if spec.id not in chain and spec.required:
                 raise InputMissingError(
                     f"Requested input {spec.id} not present in inputs at scope {scope.value}"
                 )

--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -197,14 +197,14 @@ class Node(BaseModel):
         # Node classes do not have __call__ defined and thus should not be callable
         if inspect.isclass(obj):
             if issubclass(obj, Node):
-                return obj(id=spec.id, spec=spec, enabled=spec.enabled, **params, **kwargs)
+                return obj(id=spec.id, spec=spec, enabled=enabled, **params, **kwargs)
             else:
                 return WrapClassNode(
-                    id=spec.id, cls=obj, spec=spec, params=params, enabled=spec.enabled, **kwargs
+                    id=spec.id, cls=obj, spec=spec, params=params, enabled=enabled, **kwargs
                 )
         else:
             return WrapFuncNode(
-                id=spec.id, fn=obj, spec=spec, params=params, enabled=spec.enabled, **kwargs
+                id=spec.id, fn=obj, spec=spec, params=params, enabled=enabled, **kwargs
             )
 
     @property

--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -176,6 +176,18 @@ class Node(BaseModel):
             ):
                 raise ValueError("No input collection supplied, but inputs specified in params")
 
+        # determine enabledness
+        if isinstance(spec.enabled, str):
+            if not input_collection:
+                raise ValueError(
+                    "No input collection supplied, "
+                    f"but inputs specified as determining enabledness of node {spec.id}"
+                )
+
+            enabled = bool(input_collection.get(spec.enabled.split('.', 1)[-1]))
+        else:
+            enabled = spec.enabled
+
         # additional kwargs that can be present or absent without default
         kwargs = {}
         if spec.stateful is not None:

--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -184,7 +184,7 @@ class Node(BaseModel):
                     f"but inputs specified as determining enabledness of node {spec.id}"
                 )
 
-            enabled = bool(input_collection.get(spec.enabled.split('.', 1)[-1]))
+            enabled = bool(input_collection.get(spec.enabled.split(".", 1)[-1]))
         else:
             enabled = spec.enabled
 

--- a/packages/noob/src/noob/node/spec.py
+++ b/packages/noob/src/noob/node/spec.py
@@ -141,10 +141,12 @@ class NodeSpecification(BaseModel):
     parameterized the signature of a function node, or
     by a TypedDict for a class node.
     """
-    enabled: bool = True
+    enabled: bool | AbsoluteIdentifier = True
     """
     If this flag is False, the node will not be initialized 
     or included in the `:meth:.Tube.graph`.
+    
+    Can also accept an `input` signal, and its truthiness determines whether the node is enabled.
     """
     stateful: bool | None = None
     """
@@ -173,6 +175,14 @@ class NodeSpecification(BaseModel):
             if signal in seen:
                 raise ValueError(f"Duplicate signal in dependencies: {signal}")
             seen.add(signal)
+        return val
+
+    @field_validator("enabled", mode="after")
+    @classmethod
+    def enabled_is_bool_or_input(cls, val: bool | AbsoluteIdentifier) -> bool | AbsoluteIdentifier:
+        """If the "enabled" value is a string, it must be a reference to an input value"""
+        if isinstance(val, str):
+            assert val.startswith('input.'), "Dynamic computation of enabled can only be performed from a tube-scoped input"
         return val
 
     @computed_field  # type: ignore[prop-decorator]

--- a/packages/noob/src/noob/node/spec.py
+++ b/packages/noob/src/noob/node/spec.py
@@ -182,7 +182,9 @@ class NodeSpecification(BaseModel):
     def enabled_is_bool_or_input(cls, val: bool | AbsoluteIdentifier) -> bool | AbsoluteIdentifier:
         """If the "enabled" value is a string, it must be a reference to an input value"""
         if isinstance(val, str):
-            assert val.startswith('input.'), "Dynamic computation of enabled can only be performed from a tube-scoped input"
+            assert val.startswith(
+                "input."
+            ), "Dynamic computation of enabled can only be performed from a tube-scoped input"
         return val
 
     @computed_field  # type: ignore[prop-decorator]

--- a/packages/noob/src/noob/node/tube.py
+++ b/packages/noob/src/noob/node/tube.py
@@ -20,6 +20,7 @@ class TubeNode(Node):
     A node that contains another tube within it
     """
 
+    spec: NodeSpecification  # not optional for tube nodes
     tube: ConfigSource
 
     _tube: Union["Tube", None] = None
@@ -40,9 +41,18 @@ class TubeNode(Node):
     def init(self, context: RunnerContext) -> None:  # type: ignore[override]
         from noob import SynchronousRunner, Tube
 
-        input_collection = context['input_collection']
-        input_params = input_collection.get_node_params({k:v for k,v in self.spec.params.items() if k != 'tube'})
-        extra_params = {k:v for k,v in self.__pydantic_extra__.items() if k not in input_params}
+        spec_params = self.spec.params if self.spec.params else {}
+
+        input_collection = context["input_collection"]
+        input_params = input_collection.get_node_params(
+            {k: v for k, v in spec_params.items() if k != "tube"}
+        )
+        if self.__pydantic_extra__:
+            extra_params = {
+                k: v for k, v in self.__pydantic_extra__.items() if k not in input_params
+            }
+        else:
+            extra_params = {}
 
         with warnings.catch_warnings(action="ignore", category=ExtraInputWarning):
             self._tube = Tube.from_specification(

--- a/packages/noob/src/noob/node/tube.py
+++ b/packages/noob/src/noob/node/tube.py
@@ -2,6 +2,8 @@ import warnings
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Union
 
+from pydantic import ConfigDict
+
 from noob.edge import Slot
 from noob.exceptions import ExtraInputWarning
 from noob.node.base import Node
@@ -24,6 +26,8 @@ class TubeNode(Node):
     _tube_spec: Union["TubeSpecification", None] = None
     _runner: Union["TubeRunner", None] = None
 
+    model_config = ConfigDict(extra="allow")
+
     @property
     def tube_spec(self) -> "TubeSpecification":
         from noob.tube import TubeSpecification
@@ -36,9 +40,13 @@ class TubeNode(Node):
     def init(self, context: RunnerContext) -> None:  # type: ignore[override]
         from noob import SynchronousRunner, Tube
 
+        input_collection = context['input_collection']
+        input_params = input_collection.get_node_params({k:v for k,v in self.spec.params.items() if k != 'tube'})
+        extra_params = {k:v for k,v in self.__pydantic_extra__.items() if k not in input_params}
+
         with warnings.catch_warnings(action="ignore", category=ExtraInputWarning):
             self._tube = Tube.from_specification(
-                self.tube, input={**context["tube"].input_collection.chain}
+                self.tube, input={**input_collection.chain, **input_params, **extra_params}
             )
         self._runner = SynchronousRunner(tube=self._tube)
         self._runner.init()

--- a/packages/noob/src/noob/runner/base.py
+++ b/packages/noob/src/noob/runner/base.py
@@ -435,7 +435,7 @@ class TubeRunner(ABC):
         pass
 
     def get_context(self) -> RunnerContext:
-        return RunnerContext(runner=self, tube=self.tube, input_collection=self.tube.input_collection)
+        return RunnerContext(runner=self, input_collection=self.tube.input_collection)
 
     def inject_context(self, fn: Callable) -> Callable:
         """Wrap function in a partial with the runner context injected, if requested"""

--- a/packages/noob/src/noob/runner/base.py
+++ b/packages/noob/src/noob/runner/base.py
@@ -435,7 +435,7 @@ class TubeRunner(ABC):
         pass
 
     def get_context(self) -> RunnerContext:
-        return RunnerContext(runner=self, tube=self.tube)
+        return RunnerContext(runner=self, tube=self.tube, input_collection=self.tube.input_collection)
 
     def inject_context(self, fn: Callable) -> Callable:
         """Wrap function in a partial with the runner context injected, if requested"""

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -497,7 +497,7 @@ class NodeRunner(EventloopMixin):
 
     async def init_node(self) -> None:
         self._node = Node.from_specification(self.spec, self.input_collection)
-        self._node.init()
+        self.inject_context(self._node.init)()
         self.state = State.from_specification(
             specs={asset: self.asset_specs[asset] for asset in self.inits_assets}
         )

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -7,11 +7,11 @@ import os
 import signal
 import traceback
 from collections import deque
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from functools import cached_property, partial
 from itertools import count
 from types import FrameType
-from typing import Any, cast, Callable
+from typing import Any, cast
 
 import zmq
 from pydantic import ValidationError
@@ -526,14 +526,13 @@ class NodeRunner(EventloopMixin):
             self._ready_condition.notify_all()
 
     def get_context(self) -> RunnerContext:
-        return RunnerContext(runner=self, input_collection=self.input_collection)
+        return RunnerContext(runner=self, input_collection=self.input_collection)  # type: ignore[typeddict-item]
 
     def inject_context(self, fn: Callable) -> Callable:
         """Wrap function in a partial with the runner context injected, if requested"""
         sig = inspect.signature(fn)
         ctx_key = [
-            k for k, v in sig.parameters.items() if
-            v.annotation and v.annotation is RunnerContext
+            k for k, v in sig.parameters.items() if v.annotation and v.annotation is RunnerContext
         ]
         if ctx_key:
             return partial(fn, **{ctx_key[0]: self.get_context()})

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import contextlib
+import inspect
 import multiprocessing as mp
 import os
 import signal
@@ -10,7 +11,7 @@ from collections.abc import AsyncGenerator
 from functools import cached_property, partial
 from itertools import count
 from types import FrameType
-from typing import Any, cast
+from typing import Any, cast, Callable
 
 import zmq
 from pydantic import ValidationError
@@ -44,7 +45,7 @@ from noob.node import Node, NodeSpecification
 from noob.scheduler import Scheduler
 from noob.state import State
 from noob.store import EventStore
-from noob.types import Epoch
+from noob.types import Epoch, RunnerContext
 from noob.utils import iscoroutinefunction_partial
 
 
@@ -523,6 +524,21 @@ class NodeRunner(EventloopMixin):
             ):
                 self.scheduler.done(ep, "assets")
             self._ready_condition.notify_all()
+
+    def get_context(self) -> RunnerContext:
+        return RunnerContext(runner=self, input_collection=self.input_collection)
+
+    def inject_context(self, fn: Callable) -> Callable:
+        """Wrap function in a partial with the runner context injected, if requested"""
+        sig = inspect.signature(fn)
+        ctx_key = [
+            k for k, v in sig.parameters.items() if
+            v.annotation and v.annotation is RunnerContext
+        ]
+        if ctx_key:
+            return partial(fn, **{ctx_key[0]: self.get_context()})
+        else:
+            return fn
 
     def _init_sockets(self) -> None:
         self._init_loop()

--- a/packages/noob/src/noob/types.py
+++ b/packages/noob/src/noob/types.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from noob import Tube
     from noob.event import Event
     from noob.runner import TubeRunner
+    from noob.input import InputCollection
 
 CONFIG_ID_PATTERN = r"[\w\-\/#]+"
 """
@@ -223,6 +224,7 @@ AbsoluteIdentifierAdapter = TypeAdapter(AbsoluteIdentifier)
 class RunnerContext(TypedDict):
     runner: TubeRunner
     tube: Tube
+    input_collection: InputCollection
 
 
 class EpochSegment(NamedTuple):

--- a/packages/noob/src/noob/types.py
+++ b/packages/noob/src/noob/types.py
@@ -41,10 +41,9 @@ else:
     from typing import TypeIs
 
 if TYPE_CHECKING:
-    from noob import Tube
     from noob.event import Event
-    from noob.runner import TubeRunner
     from noob.input import InputCollection
+    from noob.runner import TubeRunner
 
 CONFIG_ID_PATTERN = r"[\w\-\/#]+"
 """
@@ -223,7 +222,6 @@ AbsoluteIdentifierAdapter = TypeAdapter(AbsoluteIdentifier)
 
 class RunnerContext(TypedDict):
     runner: TubeRunner
-    tube: Tube
     input_collection: InputCollection
 
 

--- a/packages/noob/tests/data/pipelines/input/input_optional.yaml
+++ b/packages/noob/tests/data/pipelines/input/input_optional.yaml
@@ -1,0 +1,34 @@
+noob_id: testing-input-optional
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.0.1
+description: |
+  - Inputs can be optional and have a default!
+  - Nodes can use an input to control enabledness
+input:
+  start:
+    scope: tube
+    type: int
+    required: false
+    default: 10
+  return_enabled:
+    scope: tube
+    type: bool
+    required: false
+    default: true
+nodes:
+  a:
+    type: noob.testing.count_source
+    params:
+      start: input.start
+  b:
+    type: noob.testing.multiply
+    depends:
+    - left: a.index
+  c:
+    type: noob.testing.multiply
+    depends:
+    - left: b.value
+  d:
+    type: return
+    depends: c.value
+    enabled: 'input.return_enabled'

--- a/packages/noob/tests/test_input.py
+++ b/packages/noob/tests/test_input.py
@@ -1,5 +1,6 @@
 import pytest
 
+from noob import Tube
 from noob.input import InputCollection, InputScope, InputSpecification
 
 pytestmark = pytest.mark.input
@@ -28,3 +29,19 @@ def test_input_defaults():
     assert inputs.get("c", {"c": "bbb"}) == "bbb"
     assert inputs.get("c") == "x"
     assert inputs.get("d") == "w"
+
+
+def test_input_optional():
+    """Inputs can be optional and be given a default"""
+    tube = Tube.from_specification("testing-input-optional")
+    assert tube.input_collection.get("start") == 10
+    tube = Tube.from_specification("testing-input-optional", input={"start": 20})
+    assert tube.input_collection.get("start") == 20
+
+
+def test_enabled_by_input():
+    """Nodes can have whether they are enabled or not controlled by an input"""
+    tube = Tube.from_specification("testing-input-optional")
+    assert tube.nodes["d"].enabled
+    tube = Tube.from_specification("testing-input-optional", input={"return_enabled": False})
+    assert not tube.nodes["d"].enabled

--- a/schema/input.schema.json
+++ b/schema/input.schema.json
@@ -48,6 +48,11 @@
       ],
       "default": null,
       "title": "Description"
+    },
+    "required": {
+      "default": true,
+      "title": "Required",
+      "type": "boolean"
     }
   },
   "required": [

--- a/schema/node.schema.json
+++ b/schema/node.schema.json
@@ -56,9 +56,16 @@
       "title": "Params"
     },
     "enabled": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ],
       "default": true,
-      "title": "Enabled",
-      "type": "boolean"
+      "title": "Enabled"
     },
     "stateful": {
       "anyOf": [

--- a/schema/tube.schema.json
+++ b/schema/tube.schema.json
@@ -118,6 +118,11 @@
           ],
           "default": null,
           "title": "Description"
+        },
+        "required": {
+          "default": true,
+          "title": "Required",
+          "type": "boolean"
         }
       },
       "required": [],
@@ -180,9 +185,16 @@
           "title": "Params"
         },
         "enabled": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
           "default": true,
-          "title": "Enabled",
-          "type": "boolean"
+          "title": "Enabled"
         },
         "stateful": {
           "anyOf": [


### PR DESCRIPTION
A handful of Input improvements from the mio branch, described in changelog.

**Added**

- Inputs can be `optional` and have a `default`. 
  These defaults have to be basic yaml types at the moment,
  more elaborate types are still TODO.
- Nodes can use a tube-scoped `input` to control their enabledness
- The `InputCollection` is now passed in the dependency-injected
  `RunnerContext`

**Fixed**
- `Tube` nodes now correctly accept params in their specs
  and forward them and other inputs to the `noob..Tube` they wrap.
- The`ZMQRunner` 's `NodeRunner` class now correctly injects
  a requested `RunnerContext`

**Changed**
- The `type` of an input can be an arbitrary python type expression instead of an absolute identifier.
  These are still unused, but they will be used for static type checking in the future.

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--234.org.readthedocs.build/en/234/

<!-- readthedocs-preview noob end -->