### PR TITLE
dump IDs when dumping asset specs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,11 @@
   Use a sets for O(1) lookups in the epoch log rather than O(n) lookups in deque.
   ~6% scheduler performance improvement.
 
+**Changed**
+
+- [`#235`](https://github.com/miniscope/noob/pull/235/) -
+  Assets (and other specifications) now include their `id` when being dumped to json
+
 ## v1000.*
 
 ### v1000.1.0 - 26-05-18
@@ -46,8 +51,6 @@
 - [`#213`](https://github.com/miniscope/noob/pull/213) - 
   An additional `NodeInfo` dictionary contains metadata about signals and slots
   derived from the combination of the node specification and the node class.
-- [`#235`](https://github.com/miniscope/noob/pull/235/) -
-  Assets (and other specifications) now include their `id` when being dumped to json
 
 ### v1000.0.1 - 26-03-15
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,6 +46,8 @@
 - [`#213`](https://github.com/miniscope/noob/pull/213) - 
   An additional `NodeInfo` dictionary contains metadata about signals and slots
   derived from the combination of the node specification and the node class.
+- [`#235`](https://github.com/miniscope/noob/pull/235/) -
+  Assets (and other specifications) now include their `id` when being dumped to json
 
 ### v1000.0.1 - 26-03-15
 

--- a/packages/noob/src/noob/asset.py
+++ b/packages/noob/src/noob/asset.py
@@ -41,7 +41,7 @@ class AssetSpecification(BaseModel):
     Specification for a single asset within a tube .yaml file.
     """
 
-    id: PythonIdentifier = Field(..., exclude=True)
+    id: PythonIdentifier
     """The unique identifier of the asset"""
     type_: AbsoluteIdentifier = Field(..., alias="type")
     """The python path to the location of the asset


### PR DESCRIPTION
as it says

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--235.org.readthedocs.build/en/235/

<!-- readthedocs-preview noob end -->