### PR TITLE
Fix recursive loading in tubes, logging when loading tubes in viewer

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,13 @@
   Use a sets for O(1) lookups in the epoch log rather than O(n) lookups in deque.
   ~6% scheduler performance improvement.
 
+**Fix**
+- [`#236`](https://github.com/miniscope/noob/pull/236) -
+  `context: recursive` when loading a tube specification actually recurses more than two levels
+- [`#236`](https://github.com/miniscope/noob/pull/236) -
+  Validation errors for tube specifications are logged rather than suppressed so it's possible to know
+  what is wrong with the spec while working on it
+
 ## v1000.*
 
 ### v1000.1.0 - 26-05-18

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,8 +40,6 @@
   Use a sets for O(1) lookups in the epoch log rather than O(n) lookups in deque.
   ~6% scheduler performance improvement.
 
-**Fix**
-
 ## v1000.*
 
 ### v1000.1.0 - 26-05-18

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,11 @@
 
 - [`#233`](https://github.com/miniscope/noob/pull/233) -
   Correctly handle nexted prefixes in JS viewer
+- [`#236`](https://github.com/miniscope/noob/pull/236) -
+  `context: recursive` when loading a tube specification actually recurses more than two levels
+- [`#236`](https://github.com/miniscope/noob/pull/236) -
+  Validation errors for tube specifications are logged rather than suppressed so it's possible to know
+  what is wrong with the spec while working on it
 - [`238`](https://github.com/miniscope/noob/pull/238) - 
   No more validation errors on type annotations on node process functions from the
   {class}`~noob.edge.Signal` class.
@@ -36,11 +41,6 @@
   ~6% scheduler performance improvement.
 
 **Fix**
-- [`#236`](https://github.com/miniscope/noob/pull/236) -
-  `context: recursive` when loading a tube specification actually recurses more than two levels
-- [`#236`](https://github.com/miniscope/noob/pull/236) -
-  Validation errors for tube specifications are logged rather than suppressed so it's possible to know
-  what is wrong with the spec while working on it
 
 ## v1000.*
 

--- a/packages/noob/src/noob/gui/view.py
+++ b/packages/noob/src/noob/gui/view.py
@@ -2,7 +2,6 @@
 View a noob tube!
 """
 
-import contextlib
 import threading
 import time
 import webbrowser
@@ -28,6 +27,8 @@ from litestar.response import Template
 from litestar.static_files import create_static_files_router
 from litestar.template.config import TemplateConfig
 
+from noob.logging import init_logger
+
 
 def _open_browser(
     url: str,
@@ -48,6 +49,8 @@ def _tube_node_ids(spec: TubeSpecification) -> list[str]:
 
 
 def make_view_app() -> Litestar:
+    logger = init_logger("gui.view")
+
     @get(path="/view/{tube_id: str}")
     async def view(tube_id: str) -> Template:
         return Template(template_name="view.html.jinja2", context={"tube_id": tube_id})
@@ -57,9 +60,12 @@ def make_view_app() -> Litestar:
         # yield the initial spec first, then reload whenever it changes
         tube_path = TubeSpecification.path_from_id(tube_id)
         spec = None
-        with contextlib.suppress(ValidationError):
+        try:
             spec = TubeSpecification.from_yaml(tube_path, context={"recursive": True})
+            logger.debug("Loaded spec: %s", spec)
             yield spec.model_dump_json()
+        except ValidationError as e:
+            logger.error("Validation error for tube: %s", e)
 
         watch_paths = [tube_path]
         if spec is not None:
@@ -67,13 +73,17 @@ def make_view_app() -> Litestar:
             nested_tubes = set(_tube_node_ids(spec))
             watch_paths.extend([TubeSpecification.path_from_id(i) for i in nested_tubes])
 
+        logger.debug("watching paths: %s", watch_paths)
+
         watcher = watchfiles.awatch(*watch_paths)
         async for _ in watcher:
             # totally fine, the spec is malformed when typing in it sometimes!
-            with contextlib.suppress(ValidationError):
+            try:
                 yield TubeSpecification.from_yaml(
                     tube_path, context={"recursive": True}
                 ).model_dump_json()
+            except ValidationError as e:
+                logger.error("Validation error for tube: %s", e)
 
     logging_config = LoggingConfig(
         root={"level": "INFO", "handlers": ["queue_listener"]},

--- a/packages/noob/src/noob/tube.py
+++ b/packages/noob/src/noob/tube.py
@@ -170,7 +170,9 @@ class TubeSpecification(ConfigYAMLMixin):
                 if node.type_ == "tube":
                     if node.params is None:
                         node.params = {}
-                    node.params["tube"] = TubeSpecification.from_any(node.params["tube"], context={"recursive": True})
+                    node.params["tube"] = TubeSpecification.from_any(
+                        node.params["tube"], context={"recursive": True}
+                    )
         return self
 
     @cached_property

--- a/packages/noob/src/noob/tube.py
+++ b/packages/noob/src/noob/tube.py
@@ -170,7 +170,7 @@ class TubeSpecification(ConfigYAMLMixin):
                 if node.type_ == "tube":
                     if node.params is None:
                         node.params = {}
-                    node.params["tube"] = TubeSpecification.from_any(node.params["tube"])
+                    node.params["tube"] = TubeSpecification.from_any(node.params["tube"], context={"recursive": True})
         return self
 
     @cached_property

--- a/packages/noob/tests/data/pipelines/recursive/recursive_grandparent.yaml
+++ b/packages/noob/tests/data/pipelines/recursive/recursive_grandparent.yaml
@@ -1,0 +1,35 @@
+noob_id: testing-recursive-grandparent
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.0.1
+description: |
+  Trivial wrapper around recursive-parent just for the sake of testing recursive tube spec loading
+input:
+  parent_start:
+    scope: tube
+    type: int
+  parent_multiply:
+    scope: process
+    type: int
+  child_start:
+    scope: tube
+    type: int
+  child_multiply:
+    scope: process
+    type: int
+
+nodes:
+  parent:
+    type: tube
+    params:
+      tube: testing-recursive-parent
+      parent_start: input.parent_start
+      child_start: input.child_start
+    depends:
+      - parent_multiply: input.parent_multiply
+      - child_multiply: input.child_multiply
+  return:
+    type: return
+    depends:
+      - index: parent.index
+      - child: parent.child
+      - parent: parent.parent

--- a/packages/noob/tests/test_tube.py
+++ b/packages/noob/tests/test_tube.py
@@ -126,3 +126,22 @@ def test_extends_merge_depends():
     merged = merge_tube_specs(left, right)
     assert len(merged["nodes"]) == 1
     assert merged["nodes"]["a"]["depends"] == right["nodes"]["a"]["depends"]
+
+
+def test_recursive_spec_load():
+    """
+    Loading a spec recursively loads all its children
+    """
+    spec = TubeSpecification.from_id("testing-recursive-grandparent", context={"recursive": True})
+
+    assert isinstance(spec.nodes["parent"].params["tube"], TubeSpecification)
+    parent = spec.nodes["parent"].params["tube"]
+    assert isinstance(parent.nodes["b"].params["tube"], TubeSpecification)
+    child = parent.nodes["b"].params["tube"]
+
+    parent_expected = TubeSpecification.from_id(
+        "testing-recursive-parent", context={"recursive": True}
+    )
+    child_expected = TubeSpecification.from_id("testing-recursive-child")
+    assert parent_expected == parent
+    assert child_expected == child


### PR DESCRIPTION
formerly the recursive tube loading wouldn't forward the recursive parameter on, so it wasn't actually recursive, it was just 2 layers. oopsies.

Also added more logging in the viewer for when loading tubes fails - this happens often because people are working on the tubes while it's running, so they are sometimes in invalid states, and currently there is no feedback for that which sucks.

todo:
- [x] changelog
- [x] tests

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--236.org.readthedocs.build/en/236/

<!-- readthedocs-preview noob end -->