### PR TITLE
A logger for every node!

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,9 @@
 
 - [`#233`](https://github.com/miniscope/noob/pull/233) -
   Preliminary representation of assets as nodes in JS viewer
+- [`#237`](https://github.com/miniscope/noob/pull/237) - 
+  {class}`~noob.node.Node`s now have an {attr}`~noob.node.Node.logger` property 
+  that lazily instantiates a logger, if accessed.
 
 **Changed**
 
@@ -28,12 +31,6 @@
 - [`#230`](https://github.com/miniscope/noob/pull/230) ([@vaishnavidesai09](https://github.com/vaishnavidesai09)) -
   Use a sets for O(1) lookups in the epoch log rather than O(n) lookups in deque.
   ~6% scheduler performance improvement.
-
-**Added**
-
-- [`#237`](https://github.com/miniscope/noob/pull/237) - 
-  {class}`~noob.node.Node`s now have an {attr}`~noob.node.Node.logger` property 
-  that lazily instantiates a logger, if accessed. 
 
 ## v1000.*
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,12 @@
   Use a sets for O(1) lookups in the epoch log rather than O(n) lookups in deque.
   ~6% scheduler performance improvement.
 
+**Added**
+
+- [`#237`](https://github.com/miniscope/noob/pull/237) - 
+  {class}`~noob.node.Node`s now have an {attr}`~noob.node.Node.logger` property 
+  that lazily instantiates a logger, if accessed. 
+
 ## v1000.*
 
 ### v1000.1.0 - 26-05-18

--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import functools
 import inspect
+import logging
 from collections.abc import Callable, Generator, Mapping
 from types import GeneratorType
 from typing import (
@@ -7,7 +10,6 @@ from typing import (
     Any,
     Self,
     TypeVar,
-    Union,
     cast,
     get_args,
 )
@@ -22,6 +24,7 @@ from pydantic import (
 )
 
 from noob.edge import Edge, Signal, Slot
+from noob.logging import init_logger
 from noob.node.spec import NodeSpecification
 from noob.types import Epoch, EventMap
 from noob.utils import iscoroutinefunction_partial, resolve_python_identifier
@@ -146,8 +149,8 @@ class Node(BaseModel):
 
     @classmethod
     def from_specification(
-        cls, spec: "NodeSpecification", input_collection: Union["InputCollection", None] = None
-    ) -> "Node":
+        cls, spec: NodeSpecification, input_collection: InputCollection | None = None
+    ) -> Node | None:
         """
         Create a node from its spec
 
@@ -317,6 +320,10 @@ class Node(BaseModel):
         (checking this on every call proves to be surprisingly expensive)
         """
         return iscoroutinefunction_partial(self.process)
+
+    @functools.cached_property
+    def logger(self) -> logging.Logger:
+        return init_logger(f"node.{self.id}")
 
     def _wrap_generator(self, proc: Callable[[], GeneratorType]) -> None:
         """

--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -150,7 +150,7 @@ class Node(BaseModel):
     @classmethod
     def from_specification(
         cls, spec: NodeSpecification, input_collection: InputCollection | None = None
-    ) -> Node | None:
+    ) -> Node:
         """
         Create a node from its spec
 


### PR DESCRIPTION
simple as, a lazy-instantiated logger that gives a standard way for nodes to get loggers so they are all in a standard namespace with their IDs.

Also fixing the old style type annotations while im' here

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--237.org.readthedocs.build/en/237/

<!-- readthedocs-preview noob end -->