### PR TITLE
Allow the type annotation on a signal be anything

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,12 @@
   Use a sets for O(1) lookups in the epoch log rather than O(n) lookups in deque.
   ~6% scheduler performance improvement.
 
+**Fix**
+
+- [`238`](https://github.com/miniscope/noob/pull/238) - 
+  No more validation errors on type annotations on node process functions from the
+  {class}`~noob.edge.Signal` class.
+
 ## v1000.*
 
 ### v1000.1.0 - 26-05-18

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,9 @@
 
 - [`#233`](https://github.com/miniscope/noob/pull/233) -
   Correctly handle nexted prefixes in JS viewer
+- [`238`](https://github.com/miniscope/noob/pull/238) - 
+  No more validation errors on type annotations on node process functions from the
+  {class}`~noob.edge.Signal` class.
 
 **Perf**
 
@@ -31,12 +34,6 @@
 - [`#230`](https://github.com/miniscope/noob/pull/230) ([@vaishnavidesai09](https://github.com/vaishnavidesai09)) -
   Use a sets for O(1) lookups in the epoch log rather than O(n) lookups in deque.
   ~6% scheduler performance improvement.
-
-**Fix**
-
-- [`238`](https://github.com/miniscope/noob/pull/238) - 
-  No more validation errors on type annotations on node process functions from the
-  {class}`~noob.edge.Signal` class.
 
 ## v1000.*
 

--- a/packages/noob/src/noob/edge.py
+++ b/packages/noob/src/noob/edge.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable, Generator
-from typing import (  # type: ignore[attr-defined]
+from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,

--- a/packages/noob/src/noob/edge.py
+++ b/packages/noob/src/noob/edge.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable, Generator
-from types import GenericAlias, UnionType
 from typing import (  # type: ignore[attr-defined]
     TYPE_CHECKING,
     Annotated,
     Any,
-    _UnionGenericAlias,
     get_args,
     get_origin,
 )
@@ -58,7 +56,7 @@ class Slot(BaseModel):
 
 class Signal(BaseModel):
     name: str
-    annotation: JsonStringable[type | None | UnionType | GenericAlias | _UnionGenericAlias]
+    annotation: JsonStringable[Any]
 
     # Unable to generate pydantic-core schema for <class 'types.UnionType'>
     model_config = ConfigDict(arbitrary_types_allowed=True)


### PR DESCRIPTION
It turns out it's pretty hard to annotate "any kind of python type annotation"  - the type we have here is both too restrictive and also uses a deprecated objects that we get warnings about all the time. Allow this to be anything - it's not user data, it's derived from the node declaration, so if it's invalid then the node is invalid.

some type annotations aren't easily pickled, but we'll cross that bridge when we come to it.

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--238.org.readthedocs.build/en/238/

<!-- readthedocs-preview noob end -->