### PR TITLE
Allow multiple assets to be updated from same node

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -127,6 +127,10 @@
 - [`238`](https://github.com/miniscope/noob/pull/238) - 
   No more validation errors on type annotations on node process functions from the
   {class}`~noob.edge.Signal` class.
+- [`#200`](https://github.com/miniscope/noob/issues/200),
+  [`#244`](https://github.com/miniscope/noob/pull/244) - 
+  Allow multiple assets to be updated from the same node,
+  either multiple signals to different assets or the same signal to multiple assets.
 
 **Removed**
 - [`#231`](https://github.com/miniscope/noob/pull/231) - 

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -497,7 +497,7 @@ class NodeRunner(EventloopMixin):
         self.state.init(AssetScope.runner, self._node.edges)
         async with self._ready_condition:
             ep = self.scheduler.add_epoch()
-            if self.state.dependencies and len(self.state.dependencies) == len(
+            if self.state.dependencies and len(self.state.dependency_assets) == len(
                 self.receives_assets_from
             ):
                 self.scheduler.done(ep, "assets")

--- a/packages/noob/src/noob/state.py
+++ b/packages/noob/src/noob/state.py
@@ -1,7 +1,7 @@
-import sys
 from collections import defaultdict
 from collections.abc import Iterator
 from contextlib import contextmanager
+from functools import cached_property
 from typing import Self, TypeAlias
 
 from pydantic import BaseModel, Field
@@ -10,20 +10,12 @@ from noob.asset import Asset, AssetScope, AssetSpecification
 from noob.edge import Edge
 from noob.event import Event, MetaEvent, MetaSignal
 from noob.input import InputCollection
-from noob.types import NodeID, PythonIdentifier
+from noob.types import NodeID, PythonIdentifier, SignalName
 
-if sys.version_info < (3, 12):
-    from typing_extensions import TypedDict
-else:
-    from typing import TypedDict
-
-
-class _AssetDependency(TypedDict):
-    asset_id: PythonIdentifier
-    signal: PythonIdentifier
-
-
-_DependencyMap: TypeAlias = dict[NodeID, _AssetDependency]
+_DependencyMap: TypeAlias = dict[NodeID, dict[SignalName, set[PythonIdentifier]]]
+"""
+Mapping from node[signal[set[asset]] - for quick lookups 
+"""
 
 
 class State(BaseModel):
@@ -39,13 +31,8 @@ class State(BaseModel):
     assets: dict[PythonIdentifier, Asset] = Field(default_factory=dict)
     dependencies: _DependencyMap = Field(default_factory=dict)
     """
-    Map from node signals that assets depend on to the asset and signal ids. 
-    See :attr:`.AssetSpecification.depends` . 
-    
-    Only those dependencies that require copying are included here
-    (assets which are not used after the node that is depended on emits them
-    don't need to be copied to protect against mutation within the same epoch
-    after they are stored).
+    Map from nodes and signals to the assets that depend on them.
+    See :attr:`.AssetSpecification.depends` .
     """
     scope_to_assets: dict[AssetScope, list[Asset]] = Field(
         default_factory=lambda: defaultdict(list)  # type: ignore[arg-type]
@@ -173,18 +160,30 @@ class State(BaseModel):
         return None if not args or all(val is None for val in args.values()) else args
 
     def update(self, events: list[Event] | list[Event | MetaEvent]) -> None:
-        """Update asset if asset depends on a node signal"""
+        """Update assets that depend on a node signal"""
+        # fast quit - don't iterate if we have no dependencies.
+        if not self.dependencies:
+            return
         for event in events:
-            if (
-                (dep := self.dependencies.get(event["node_id"]))
-                and dep["signal"] == event["signal"]
-                and event["value"] is not MetaSignal.NoEvent
+            if event["value"] is not MetaSignal.NoEvent and (
+                (signals := self.dependencies.get(event["node_id"]))
+                and (assets := signals.get(event["signal"]))
             ):
-                self.assets[dep["asset_id"]].update(
-                    value=event["value"],
-                    epoch=event["epoch"],
-                    copy=dep["asset_id"] not in self.nocopy_deps,
-                )
+                for asset_id in assets:
+                    self.assets[asset_id].update(
+                        value=event["value"],
+                        epoch=event["epoch"],
+                        copy=asset_id not in self.nocopy_deps,
+                    )
+
+    @cached_property
+    def dependency_assets(self) -> set[PythonIdentifier]:
+        """Ids of all assets that depend on a node signal"""
+        deps = set()
+        for signals in self.dependencies.values():
+            for assets in signals.values():
+                deps |= assets
+        return deps
 
     def clear(self) -> None:
         """
@@ -196,7 +195,9 @@ class State(BaseModel):
     def _get_dependencies(
         cls, specs: dict[str, AssetSpecification], edges: list[Edge] | None = None
     ) -> tuple[_DependencyMap, set[PythonIdentifier]]:
-        deps = {}
+        deps: dict[NodeID, dict[SignalName, set[PythonIdentifier]]] = defaultdict(
+            lambda: defaultdict(set)
+        )
         nocopy_deps = set()
         for asset in specs.values():
             if not asset.depends:
@@ -206,5 +207,5 @@ class State(BaseModel):
                 edge.source_node == node_id and edge.source_signal == signal for edge in edges
             ):
                 nocopy_deps.add(asset.id)
-            deps[node_id] = _AssetDependency(asset_id=asset.id, signal=signal)
+            deps[node_id][signal].add(asset.id)
         return deps, nocopy_deps

--- a/packages/noob/tests/data/pipelines/asset/asset_depends_multi.yaml
+++ b/packages/noob/tests/data/pipelines/asset/asset_depends_multi.yaml
@@ -1,0 +1,44 @@
+noob_id: testing-depends-asset-multi
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.1.1
+description: |
+  Multiple assets can be updated from the same signal
+
+assets:
+  counter:
+    type: noob.testing.counter
+    params:
+      start: 1
+    scope: runner
+    depends: c.iterator
+  counter2:
+    type: noob.testing.counter
+    depends: c.iterator
+    scope: runner
+
+nodes:
+  a:
+    type: noob.testing.increment
+    depends:
+      - iterator: assets.counter
+  b:
+    type: noob.testing.increment
+    depends:
+       - iterator: assets.counter2
+  c:
+    type: noob.testing.increment
+    depends:
+      - iterator: a.iterator
+  post_depends:
+    type: noob.testing.increment
+    depends:
+      - iterator: c.iterator
+  return:
+    type: return
+    depends:
+      - a_value: a.value
+      - a_iterator: a.iterator
+      - b_value: b.value
+      - b_iterator: b.iterator
+      - post_value: post_depends.value
+      - post_iterator: post_depends.iterator

--- a/packages/noob/tests/test_pipelines/test_asset.py
+++ b/packages/noob/tests/test_pipelines/test_asset.py
@@ -152,6 +152,30 @@ async def test_asset_depends_post_gather(loaded_tube, all_runners):
             last_b = result["b_value"]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("loaded_tube", ["testing-depends-asset-multi"], indirect=True)
+async def test_asset_depends_multi(loaded_tube, all_runners):
+    """
+    Multiple assets can be updated from the same signal
+    """
+    runner = all_runners
+    assert set(runner.tube.state.dependencies.keys()) == {"c"}
+    assert runner.tube.state.dependencies["c"]["iterator"] == {"counter", "counter2"}
+    for i in range(5):
+        if iscoroutinefunction_partial(runner.process):
+            result = await runner.process()
+        else:
+            result = runner.process()
+
+        # in the first iteration, the values should differ,
+        # but in subsequent iterations, after copied from the same signal,
+        # they are the same.
+        if i == 0:
+            assert result["a_value"] != result["b_value"]
+        else:
+            assert result["a_value"] == result["b_value"]
+
+
 def test_asset_nocopy_when_unused():
     """
     Don't copy assets when there is no chance for them to be mutated after they are stored


### PR DESCRIPTION
Fix: #200 

Previously, it was only possible to have one asset dependency mapping per node. However nodes can emit multiple signals, and the same signal might be used to update multiple assets (not exactly sure when this would be useful, but it's a logical implication of the spec and should work).

Simple enough change, using a nested dict to keep the external lookups quick (O(1) is node relevant to the update, as used in the zmq runner) - alternative considered was using `NodeSignal()` as the key but that requires allocating a tuple on every lookup.

added `dependency_assets` cached prop to get the set of assets with dependencies since the `dependencies` dict is no longer 1:1 count of assets in the value field.

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--244.org.readthedocs.build/en/244/

<!-- readthedocs-preview noob end -->