### PR TITLE
Support contextmanagers as assets

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,8 @@
   that lazily instantiates a logger, if accessed.
 - [`#244`](https://github.com/miniscope/noob/issues/239) - 
   Tube nodes propagate the signals of the enclosed tube by reading the deps of its "return" node.
+- [`246`](https://github.com/miniscope/noob/pull/246) -
+  Support contextmanagers as assets.
 
 **Changed**
 
@@ -137,6 +139,11 @@
   [`#239`](https://github.com/miniscope/noob/issues/239)
   [`#245`](https://github.com/miniscope/noob/issues/245) - 
   Correctly propagate NoEvents from nested tubes
+- [`246`](https://github.com/miniscope/noob/pull/246) -
+  Only `init` node-scoped assets when required by edges,
+  rather than initializing all assets when edges are `None`
+- [`246`](https://github.com/miniscope/noob/pull/246) -
+  Don't double-init node-scoped assets in the async runner.
 
 **Removed**
 - [`#231`](https://github.com/miniscope/noob/pull/231) - 

--- a/docs/usage/assets.md
+++ b/docs/usage/assets.md
@@ -231,6 +231,33 @@ assets:
 The format does not change much for a class-based Asset. Like its function-based twin, all `__init__` parameters must
 be defined in the `params` section.
 
+### `contextmanager` Assets
+
+Assets can also be written as [context managers](https://docs.python.org/3/library/contextlib.html).
+
+Assets are a static object with setup and teardown,
+which fits perfectly into the design of contextmanagers:
+
+- Setup the asset before the `yield`
+- The object that is `yield`-ed is the asset
+- Teardown the object after the `yield`
+
+```python
+from contextlib import contextmanager
+
+@contextmanager
+def some_asset(*args, **kwargs) -> SomeObject:
+    # setup the asset here, this runs during `init`
+    something = make_asset(*args, **kwargs)
+    
+    # yield the asset
+    try:
+        yield something
+    finally:
+        # teardown the asset, this runs during `deinit`
+        something.close()
+```
+
 ### How do you use an Asset?
 
 The defined asset then can simply become a `depends` input for any node and used like any regular Python object,

--- a/packages/noob/src/noob/asset.py
+++ b/packages/noob/src/noob/asset.py
@@ -1,10 +1,11 @@
+import contextlib
 import inspect
 from collections.abc import Callable
 from copy import deepcopy
 from enum import StrEnum
 from typing import Any, Generic, ParamSpec, Self, TypeVar, Union
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 from noob.input import InputCollection
 from noob.types import AbsoluteIdentifier, DependencyIdentifier, Epoch, PythonIdentifier
@@ -206,15 +207,31 @@ class WrapFuncAsset(Asset):
     The function effectively takes the role of :meth:`.__init__`, with the outer wrapping class
     `params` being injected as function parameters. The output of the function becomes the
     asset object.
+
+    Functions that return a context manager,
+    e.g. those wrapped with :func:`contextlib.contextmanager`,
+    are also supported:
+    the context manager is entered during :meth:`.init`, the yielded value becomes the
+    asset object, and the context manager is exited during :meth:`.deinit`.
     """
 
     fn: Callable
 
+    _cm: Any = PrivateAttr(default=None)
+
     def init(self) -> None:
-        if isinstance(self.params, list):
-            self.obj = self.fn(*self.params)
+        obj = self.fn(*self.params) if isinstance(self.params, list) else self.fn(**self.params)
+
+        if isinstance(obj, contextlib.AbstractContextManager):
+            self._cm = obj
+            self.obj = self._cm.__enter__()
         else:
-            self.obj = self.fn(**self.params)
+            self.obj = obj
 
     def deinit(self) -> None:
+        if self._cm is not None:
+            try:
+                self._cm.__exit__(None, None, None)
+            finally:
+                self._cm = None
         self.obj = None

--- a/packages/noob/src/noob/runner/asyncio.py
+++ b/packages/noob/src/noob/runner/asyncio.py
@@ -75,7 +75,7 @@ class AsyncRunner(TubeRunner):
                     await self._task_sem.acquire()
                     self._process_node(node_info=node_info, input=input)
 
-            self._after_process()
+            await self._after_process()
             result = self.collect_return()
         return result
 
@@ -155,7 +155,11 @@ class AsyncRunner(TubeRunner):
     async def _before_process(self) -> None:  # type: ignore[override]
         if not self._running.is_set():
             await self.init()
+        self.tube.state.init(AssetScope.process)
         self.store.clear()
+
+    async def _after_process(self) -> None:
+        self.tube.state.deinit(AssetScope.process)
 
     async def _get_ready(self, epoch: Epoch | None = None) -> AsyncGenerator[list[MetaEvent]]:  # type: ignore[override]
         if self._exception:
@@ -209,12 +213,14 @@ class AsyncRunner(TubeRunner):
             return
 
         value = future.result()
+        self.tube.state.deinit(AssetScope.node, node.edges)
+
         events = self.store.add_value(node.signals, value, node.id, epoch)
+
         if events is not None:
             all_events = self.tube.scheduler.update(events)
             if node.id in self.tube.state.dependencies:
                 self.tube.state.update(events)
-            self.tube.state.deinit(AssetScope.node, node.edges)
             self._call_callbacks(all_events)
         self._task_sem.release()
         self._node_ready.set()

--- a/packages/noob/src/noob/runner/asyncio.py
+++ b/packages/noob/src/noob/runner/asyncio.py
@@ -145,7 +145,6 @@ class AsyncRunner(TubeRunner):
         node = self._get_node(node_id)
 
         # FIXME: since nodes can run quasiconcurrently, need to ensure unique assets per node
-        self.tube.state.init(AssetScope.node, node.edges)
         args, kwargs = self._collect_input(node, epoch, input)
         node, args, kwargs = self._before_call_node(node, *args, **kwargs)
         value = self._call_node(node, *args, **kwargs)
@@ -158,7 +157,7 @@ class AsyncRunner(TubeRunner):
         self.tube.state.init(AssetScope.process)
         self.store.clear()
 
-    async def _after_process(self) -> None:
+    async def _after_process(self) -> None:  # type: ignore[override]
         self.tube.state.deinit(AssetScope.process)
 
     async def _get_ready(self, epoch: Epoch | None = None) -> AsyncGenerator[list[MetaEvent]]:  # type: ignore[override]

--- a/packages/noob/src/noob/runner/asyncio.py
+++ b/packages/noob/src/noob/runner/asyncio.py
@@ -215,7 +215,6 @@ class AsyncRunner(TubeRunner):
         self.tube.state.deinit(AssetScope.node, node.edges)
 
         events = self.store.add_value(node.signals, value, node.id, epoch)
-
         if events is not None:
             all_events = self.tube.scheduler.update(events)
             if node.id in self.tube.state.dependencies:

--- a/packages/noob/src/noob/runner/base.py
+++ b/packages/noob/src/noob/runner/base.py
@@ -316,7 +316,7 @@ class TubeRunner(ABC):
         if "epoch" in node.injections:
             inputs |= {node.injections["epoch"]: epoch}
 
-        self.tube.state.init(AssetScope.node)
+        self.tube.state.init(AssetScope.node, edges)
         state_inputs = self.tube.state.collect(edges)
         inputs |= state_inputs if state_inputs else inputs
 

--- a/packages/noob/src/noob/runner/zmq/node.py
+++ b/packages/noob/src/noob/runner/zmq/node.py
@@ -289,6 +289,7 @@ class NodeRunner(EventloopMixin):
 
     async def _process_loop(self) -> None:
         self._node = cast(Node, self._node)
+        edges = self._node.edges
         is_async = iscoroutinefunction_partial(self._node.process)
         loop = asyncio.get_running_loop()
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
@@ -302,6 +303,9 @@ class NodeRunner(EventloopMixin):
                 else:
                     part = partial(self._node.process, *args, **kwargs)
                     value = await loop.run_in_executor(executor, part)
+
+                # deinit node-scoped assets here before sending in case deinit mutates
+                self.state.deinit(AssetScope.node, edges)
 
                 # update internal scheduler state and send events
                 events = self.store.add_value(self._node.signals, value, self._node.id, epoch)
@@ -339,7 +343,9 @@ class NodeRunner(EventloopMixin):
 
             args, kwargs = self.store.split_args_kwargs(inputs)
             yield args, kwargs, ready["epoch"]
-            self.state.deinit(AssetScope.node, edges)
+
+            # deinit process scoped assets here, after publishing events,
+            # mimicking sync behavior of whether nodes would "see" a deinit mutation.
             self.state.deinit(AssetScope.process, edges)
             self.store.clear(epoch)
 

--- a/packages/noob/src/noob/state.py
+++ b/packages/noob/src/noob/state.py
@@ -92,11 +92,14 @@ class State(BaseModel):
 
         For :attr:`.AssetScope.node` ,
         should provide the nodes edges to determine which assets to initialize, if any.
-        If not passed, all node-scoped assets are initialized
         """
         to_init: set[str] | None = None
-        if scope == AssetScope.node and edges is not None:
+        if scope == AssetScope.node:
+            if not edges:
+                return
             to_init = set(edge.source_signal for edge in edges if edge.source_node == "assets")
+            if not to_init:
+                return
 
         for asset in self.scope_to_assets.get(scope, []):
             if to_init is None or asset.id in to_init:

--- a/packages/noob/src/noob/testing/__init__.py
+++ b/packages/noob/src/noob/testing/__init__.py
@@ -1,4 +1,4 @@
-from noob.testing.assets import AnyAsset, Initializer, counter
+from noob.testing.assets import AnyAsset, Initializer, LifecycleCounter, counter, counter_cm
 from noob.testing.nodes import (
     CountSource,
     CountSourceDecor,
@@ -77,7 +77,9 @@ __all__ = [
     "StatefulMultiply",
     "UnannotatedGenerator",
     "counter",
+    "counter_cm",
     "CountSourceDecor",
+    "LifecycleCounter",
     "increment",
     "inject_epoch",
     "inject_eventmap",

--- a/packages/noob/src/noob/testing/assets.py
+++ b/packages/noob/src/noob/testing/assets.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from contextlib import contextmanager
 from typing import Any
 
 from noob.asset import Asset
@@ -29,6 +30,27 @@ class counter(Generator):
     @property
     def current(self) -> int:
         return self._current
+
+
+class LifecycleCounter(counter):
+    """Counter that records when its context manager has been entered and exited"""
+
+    def __init__(self, start: int = 0) -> None:
+        super().__init__(start)
+        self.entered = 0
+        self.exited = 0
+
+
+@contextmanager
+def counter_cm(start: int = 0) -> Generator[LifecycleCounter, None, None]:
+    c = LifecycleCounter(start)
+    c.entered += 1
+    _ = next(c)
+    try:
+        yield c
+    finally:
+        _ = next(c)
+        c.exited += 1
 
 
 class Initializer(Asset):

--- a/packages/noob/tests/data/pipelines/asset/asset_contextmanager.yaml
+++ b/packages/noob/tests/data/pipelines/asset/asset_contextmanager.yaml
@@ -1,0 +1,60 @@
+noob_id: testing-contextmanager-asset
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.1.1.dev86+gcf9e11b.d20250725
+
+assets:
+  runner_counter:
+    type: noob.testing.counter_cm
+    params:
+      start: 1
+    scope: runner
+    depends: runner_b.iterator
+  process_counter:
+    type: noob.testing.counter_cm
+    params:
+      start: 1
+    scope: process
+  node_counter:
+    type: noob.testing.counter_cm
+    params:
+      start: 1
+    scope: node
+
+nodes:
+  node_a:
+    type: noob.testing.increment
+    depends: [{iterator: assets.node_counter}]
+  node_b:
+    type: noob.testing.increment
+    depends: [{iterator: node_a.iterator}]
+
+  process_a:
+    type: noob.testing.increment
+    depends: [{iterator: assets.process_counter}]
+  process_b:
+    type: noob.testing.increment
+    depends: [{iterator: process_a.iterator}]
+
+  runner_a:
+    type: noob.testing.increment
+    depends: [{iterator: assets.runner_counter}]
+  runner_b:
+    type: noob.testing.increment
+    depends: [{iterator: runner_a.iterator}]
+
+
+  return:
+    type: return
+    depends:
+      - node_a: node_a.iterator
+      - node_b: node_b.iterator
+      - process_a: process_a.iterator
+      - process_b: process_b.iterator
+      - runner_a: runner_a.iterator
+      - runner_b: runner_b.iterator
+      - node_a_value: node_a.value
+      - node_b_value: node_b.value
+      - process_a_value: process_a.value
+      - process_b_value: process_b.value
+      - runner_a_value: runner_a.value
+      - runner_b_value: runner_b.value

--- a/packages/noob/tests/test_pipelines/test_asset.py
+++ b/packages/noob/tests/test_pipelines/test_asset.py
@@ -252,6 +252,7 @@ async def test_contextmanager_asset_lifecycle(loaded_tube, all_runners):
     its yielded value is the asset object, and it is exited on deinit.
     """
     runner = all_runners
+    not_zmq = not isinstance(runner, ZMQRunner)
 
     for i in range(3):
         if iscoroutinefunction_partial(runner.process):
@@ -271,9 +272,9 @@ async def test_contextmanager_asset_lifecycle(loaded_tube, all_runners):
 
         # process scoped assets can be shared and are not deinit'd before sharing
         assert result["process_a"].entered == 1
-        assert result["process_a"].exited == 1
+        assert result["process_a"].exited == (1 if not_zmq else 0)
         assert result["process_b"].entered == 1
-        assert result["process_b"].exited == 1
+        assert result["process_b"].exited == (1 if not_zmq else 0)
         assert result["process_a_value"] == 2
         assert result["process_b_value"] == 3
 

--- a/packages/noob/tests/test_pipelines/test_asset.py
+++ b/packages/noob/tests/test_pipelines/test_asset.py
@@ -1,8 +1,9 @@
 import pytest
 
 from noob import SynchronousRunner, Tube
-from noob.asset import AssetScope
+from noob.asset import Asset, AssetScope, AssetSpecification, WrapFuncAsset
 from noob.runner.zmq import ZMQRunner
+from noob.testing import LifecycleCounter
 from noob.types import Epoch
 from noob.utils import iscoroutinefunction_partial
 
@@ -218,3 +219,68 @@ def test_selective_node_init():
 
         with runner._asset_context(AssetScope.node, no.edges):
             assert not runner.tube.state.assets["initializer"].obj
+
+
+def test_contextmanager_asset():
+    """
+    WrapFuncAsset enters and exits a contextmanager factory directly,
+    and can be re-initialized after deinit.
+    """
+    spec = AssetSpecification(
+        id="counter", type="noob.testing.counter_cm", scope="runner", params={"start": 0}
+    )
+    asset = Asset.from_specification(spec)
+    assert isinstance(asset, WrapFuncAsset)
+
+    asset.init()
+    obj = asset.obj
+    assert isinstance(obj, LifecycleCounter)
+    assert obj.entered == 1
+    assert obj.exited == 0
+
+    asset.deinit()
+    assert obj.entered == 1
+    assert obj.exited == 1
+    assert asset.obj is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("loaded_tube", ["testing-contextmanager-asset"], indirect=True)
+async def test_contextmanager_asset_lifecycle(loaded_tube, all_runners):
+    """
+    A ``contextlib.contextmanager``-decorated factory is entered on init,
+    its yielded value is the asset object, and it is exited on deinit.
+    """
+    runner = all_runners
+
+    for i in range(3):
+        if iscoroutinefunction_partial(runner.process):
+            result = await runner.process()
+        else:
+            result = runner.process()
+
+        # node scoped assets can be shared but are deinited before being shared
+        assert result["node_a"].entered == 1
+        assert result["node_a"].exited == 1
+        assert result["node_b"].entered == 1
+        assert result["node_b"].exited == 1
+
+        # advanced twice - once when the asset is deinit'd after node a, and again during b
+        assert result["node_a_value"] == 2
+        assert result["node_b_value"] == 4
+
+        # process scoped assets can be shared and are not deinit'd before sharing
+        assert result["process_a"].entered == 1
+        assert result["process_a"].exited == 1
+        assert result["process_b"].entered == 1
+        assert result["process_b"].exited == 1
+        assert result["process_a_value"] == 2
+        assert result["process_b_value"] == 3
+
+        # runner scoped assets are kept alive while the runner is!
+        assert result["runner_a"].entered == 1
+        assert result["runner_a"].exited == 0
+        assert result["runner_b"].entered == 1
+        assert result["runner_b"].exited == 0
+        assert result["runner_a_value"] == 2 + (2 * i)
+        assert result["runner_b_value"] == 3 + (2 * i)

--- a/packages/noob/tests/test_state.py
+++ b/packages/noob/tests/test_state.py
@@ -1,5 +1,9 @@
+import pytest
+
 from noob.asset import AssetScope, AssetSpecification
 from noob.state import State
+
+pytestmark = pytest.mark.assets
 
 
 def test_non_equivalent_event(non_equivalent_event):
@@ -22,3 +26,21 @@ def test_non_equivalent_event(non_equivalent_event):
     )
     # no error is thrown
     state.update([non_equivalent_event])
+
+
+def test_edgeless_nodes_dont_init():
+    """
+    Regression - ensure that nodes with falsy edge collections
+    don't cause all node-scoped assets to init
+    """
+    spec = AssetSpecification(
+        id="counter", type="noob.testing.counter_cm", scope="node", params={"start": 0}
+    )
+
+    state = State.from_specification(specs={"counter": spec})
+
+    state.init(AssetScope.node, edges=None)
+    assert state.assets["counter"].obj is None
+
+    state.init(AssetScope.node, edges=[])
+    assert state.assets["counter"].obj is None


### PR DESCRIPTION
Part of #110 but doesn't close it.

This is the first half of the issue, allowing contextmanagers as assets, but it does *not* address the main point of the issue, which is about providing some kind of "middleware" that can wrap around nodes for repeated operations across nodes.

This PR just makes it possible to use contextmanagers as assets, simple as.

however during testing, discovered a few bugs in how assets were handling both in the base runner and the async runner:
- The base runner was not passing edges to the state when initializing node-scoped assets, so all node-scoped assets were initialized every time (bad)
- The logic in `state` was flawed to allow that to happen - we should only initialize node-scoped assets when they are directly depended on by the node.
- async runner double-initialized node-scoped assets, and didn't deinit process-scoped assets.

These were discovered here because the test for the contextmanager included init/deinit counts, which were off in the flawed code. the tests here do *not* test global counts of init/deinit, just *per asset instance*, so further testing to constrain the behavior would be good here.

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--246.org.readthedocs.build/en/246/

<!-- readthedocs-preview noob end -->