### PR TITLE
Handle generator exhaustion

### DIFF
--- a/packages/noob/src/noob/__init__.py
+++ b/packages/noob/src/noob/__init__.py
@@ -2,14 +2,14 @@
 
 from noob.config import config as cfg
 from noob.logging import init_logger
+from noob.types import Epoch, Name
+from noob.event import Event, NoEventable, MetaEvent, MetaSignal
 from noob.node import process_method, Node, NodeSpecification
 from noob.asset import Asset, AssetSpecification
 from noob.state import State
 from noob.input import InputCollection, InputScope, InputSpecification
 from noob.tube import Tube, TubeClassicEdition, TubeSpecification
 from noob.runner import SynchronousRunner
-from noob.types import Epoch, Name
-from noob.event import Event, NoEventable, MetaEvent, MetaSignal
 
 __all__ = [
     "Asset",

--- a/packages/noob/src/noob/event.py
+++ b/packages/noob/src/noob/event.py
@@ -102,6 +102,9 @@ class MetaEventType(StrEnum):
 
 class MetaSignal(StrEnum):
     NoEvent = f"{META_SIGNAL}NoEvent"
+    """No event was emitted! Expire all dependent nodes"""
+    Exhausted = f"{META_SIGNAL}Exhausted"
+    """A node has no more remaining events to yield."""
 
 
 class MetaEvent(Event):

--- a/packages/noob/src/noob/exceptions.py
+++ b/packages/noob/src/noob/exceptions.py
@@ -65,12 +65,6 @@ class AlreadyRunningError(RunnerError, RuntimeError):
     """
 
 
-class GeneratorExhaustedError(RunnerError, RuntimeError):
-    """
-    A generator node was exhausted and can produce no more events.
-    """
-
-
 class InputMissingError(InputError, ValueError):
     """
     A requested input was not provided in the given scope

--- a/packages/noob/src/noob/exceptions.py
+++ b/packages/noob/src/noob/exceptions.py
@@ -65,6 +65,12 @@ class AlreadyRunningError(RunnerError, RuntimeError):
     """
 
 
+class GeneratorExhaustedError(RunnerError, RuntimeError):
+    """
+    A generator node was exhausted and can produce no more events.
+    """
+
+
 class InputMissingError(InputError, ValueError):
     """
     A requested input was not provided in the given scope

--- a/packages/noob/src/noob/exceptions.py
+++ b/packages/noob/src/noob/exceptions.py
@@ -112,3 +112,9 @@ class TerminateTaskGroup(NoobError):
     """
     https://docs.python.org/3/library/asyncio-task.html#terminating-a-task-group
     """
+
+
+class NodeExhaustedError(RunnerError, RuntimeError):
+    """
+    A node is exhausted, the tube can't be run until it's re-initialized
+    """

--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -24,7 +24,7 @@ from pydantic import (
 )
 
 from noob.edge import Edge, Signal, Slot
-from noob.event import EventMaker
+from noob.event import EventMaker, MetaSignal
 from noob.logging import init_logger
 from noob.node.spec import NodeSpecification
 from noob.types import Epoch, EventMap
@@ -344,16 +344,19 @@ class Node(BaseModel):
     def logger(self) -> logging.Logger:
         return init_logger(f"node.{self.id}")
 
-    def _wrap_generator(self, proc: Callable[[], GeneratorType]) -> None:
+    def _wrap_generator(self, proc: Callable[[Any], GeneratorType], **params: Any) -> None:
         """
         Wrap a `process` method when it is a generator,
         invoked in `model_post_init`
         """
-        self._gen = proc()
+        self._gen = proc(**params)
 
         def _process():  # noqa: ANN202
             self._gen = cast(Generator, self._gen)
-            return next(self._gen)
+            try:
+                return next(self._gen)
+            except StopIteration:
+                return MetaSignal.Exhausted
 
         signature = inspect.signature(self.process)
 
@@ -466,12 +469,19 @@ class WrapFuncNode(Node):
         and create a :func:`functools.partial` of it if it is not.
         """
         if inspect.isgeneratorfunction(self.fn):
-            self._gen = self.fn(**self.params)
-            self.__dict__["process"] = lambda: next(self._gen)
+            self._wrap_generator(self.fn, **self.params)
         elif inspect.isasyncgenfunction(self.fn):
             raise NotImplementedError("async generators not supported")
         else:
             self.__dict__["process"] = functools.partial(self.fn, **self.params)
+
+    def init(self) -> None:
+        if inspect.isgeneratorfunction(self.fn) and self._gen is None:
+            self._wrap_generator(self.fn, **self.params)
+
+    def deinit(self) -> None:
+        if inspect.isgeneratorfunction(self.fn):
+            self._gen = None
 
     @model_validator(mode="wrap")
     @classmethod

--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -25,7 +25,6 @@ from pydantic import (
 
 from noob.edge import Edge, Signal, Slot
 from noob.event import EventMaker
-from noob.exceptions import GeneratorExhaustedError
 from noob.logging import init_logger
 from noob.node.spec import NodeSpecification
 from noob.types import Epoch, EventMap
@@ -354,10 +353,7 @@ class Node(BaseModel):
 
         def _process():  # noqa: ANN202
             self._gen = cast(Generator, self._gen)
-            try:
-                return next(self._gen)
-            except StopIteration as e:
-                raise GeneratorExhaustedError(f"Generator node {self.id!r} is exhausted") from e
+            return next(self._gen)
 
         signature = inspect.signature(self.process)
 
@@ -471,16 +467,7 @@ class WrapFuncNode(Node):
         """
         if inspect.isgeneratorfunction(self.fn):
             self._gen = self.fn(**self.params)
-
-            def _process():  # noqa: ANN202
-                try:
-                    return next(self._gen)
-                except StopIteration as e:
-                    raise GeneratorExhaustedError(
-                        f"Generator node {self.id!r} is exhausted"
-                    ) from e
-
-            self.__dict__["process"] = _process
+            self.__dict__["process"] = lambda: next(self._gen)
         elif inspect.isasyncgenfunction(self.fn):
             raise NotImplementedError("async generators not supported")
         else:

--- a/packages/noob/src/noob/node/base.py
+++ b/packages/noob/src/noob/node/base.py
@@ -25,6 +25,7 @@ from pydantic import (
 
 from noob.edge import Edge, Signal, Slot
 from noob.event import EventMaker
+from noob.exceptions import GeneratorExhaustedError
 from noob.logging import init_logger
 from noob.node.spec import NodeSpecification
 from noob.types import Epoch, EventMap
@@ -353,7 +354,10 @@ class Node(BaseModel):
 
         def _process():  # noqa: ANN202
             self._gen = cast(Generator, self._gen)
-            return next(self._gen)
+            try:
+                return next(self._gen)
+            except StopIteration as e:
+                raise GeneratorExhaustedError(f"Generator node {self.id!r} is exhausted") from e
 
         signature = inspect.signature(self.process)
 
@@ -467,7 +471,16 @@ class WrapFuncNode(Node):
         """
         if inspect.isgeneratorfunction(self.fn):
             self._gen = self.fn(**self.params)
-            self.__dict__["process"] = lambda: next(self._gen)
+
+            def _process():  # noqa: ANN202
+                try:
+                    return next(self._gen)
+                except StopIteration as e:
+                    raise GeneratorExhaustedError(
+                        f"Generator node {self.id!r} is exhausted"
+                    ) from e
+
+            self.__dict__["process"] = _process
         elif inspect.isasyncgenfunction(self.fn):
             raise NotImplementedError("async generators not supported")
         else:

--- a/packages/noob/src/noob/runner/asyncio.py
+++ b/packages/noob/src/noob/runner/asyncio.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from noob.asset import AssetScope
 from noob.event import MetaEvent
-from noob.exceptions import GeneratorExhaustedError, InputMissingError
+from noob.exceptions import InputMissingError
 from noob.input import InputScope
 from noob.node import Node, Return
 from noob.runner.base import TubeRunner
@@ -89,12 +89,6 @@ class AsyncRunner(TubeRunner):
                 "Use `process()` directly, providing required inputs to each call."
             ) from e
 
-        if self._exhausted:
-            raise GeneratorExhaustedError(
-                "Tube is exhausted: a generator node ran out of values in a previous run. "
-                "Create a new runner to run again."
-            )
-
         await self.init()
         current_iter = 0
         has_return = any(isinstance(node, Return) for node in self.tube.nodes.values())
@@ -113,9 +107,6 @@ class AsyncRunner(TubeRunner):
 
                 yield ret
                 current_iter += 1
-        except GeneratorExhaustedError:
-            self._exhausted = True
-            return
         finally:
             await self.deinit()
 

--- a/packages/noob/src/noob/runner/asyncio.py
+++ b/packages/noob/src/noob/runner/asyncio.py
@@ -1,12 +1,13 @@
 import asyncio
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, MutableSequence
 from dataclasses import dataclass, field
 from functools import partial
 from typing import Any
 
+from noob import Event
 from noob.asset import AssetScope
-from noob.event import MetaEvent
-from noob.exceptions import InputMissingError
+from noob.event import MetaEvent, MetaSignal
+from noob.exceptions import InputMissingError, NodeExhaustedError
 from noob.input import InputScope
 from noob.node import Node, Return
 from noob.runner.base import TubeRunner
@@ -65,6 +66,8 @@ class AsyncRunner(TubeRunner):
         If a node raises an error, we allow the other running nodes to complete
         (with some timeout)
         """
+        if self._exhausted:
+            raise NodeExhaustedError("Tube was exhausted, need to reinit to run")
         input = self._validate_input(**kwargs)
         with self._asset_context(AssetScope.process):
             await self._before_process()
@@ -93,20 +96,23 @@ class AsyncRunner(TubeRunner):
         current_iter = 0
         has_return = any(isinstance(node, Return) for node in self.tube.nodes.values())
         try:
-            while n is None or current_iter < n:
+            while self.running and (n is None or current_iter < n):
                 ret = None
                 loop = 0
                 if not has_return:
                     ret = await self.process()
                 else:
-                    while ret is None:
+                    while self.running and ret is None:
                         ret = await self.process()
+                        await asyncio.sleep(0)
                         loop += 1
                         if loop > self.max_iter_loops:
                             raise RuntimeError("Reached maximum process calls per iteration")
 
                 yield ret
                 current_iter += 1
+        except NodeExhaustedError:
+            self._logger.info("Iteration stopped because node was exhausted")
         finally:
             await self.deinit()
 
@@ -133,6 +139,7 @@ class AsyncRunner(TubeRunner):
 
             self.inject_context(self.tube.state.deinit)(AssetScope.runner)
 
+        self._exhausted = False
         self._running.clear()
 
     @property
@@ -216,6 +223,7 @@ class AsyncRunner(TubeRunner):
                 self.tube.state.update(events)
             self.tube.state.deinit(AssetScope.node, node.edges)
             self._call_callbacks(all_events)
+            self._handle_exhaustion(all_events)
         self._task_sem.release()
         self._node_ready.set()
         self._logger.debug("Node %s emitted %s in epoch %s", node.id, value, epoch)
@@ -243,6 +251,14 @@ class AsyncRunner(TubeRunner):
             raise self._exception from e
         else:
             raise self._exception
+
+    def _handle_exhaustion(self, events: MutableSequence[Event | MetaEvent]) -> bool:
+        for e in events:
+            if e["value"] is MetaSignal.Exhausted:
+                self._running.clear()
+                self._exhausted = True
+                self._exception = NodeExhaustedError(f"Node {e['node_id']} is exhausted!")
+        return False
 
     def enable_node(self, node_id: str) -> None:
         self.tube.nodes[node_id].init()

--- a/packages/noob/src/noob/runner/asyncio.py
+++ b/packages/noob/src/noob/runner/asyncio.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from noob.asset import AssetScope
 from noob.event import MetaEvent
-from noob.exceptions import InputMissingError
+from noob.exceptions import GeneratorExhaustedError, InputMissingError
 from noob.input import InputScope
 from noob.node import Node, Return
 from noob.runner.base import TubeRunner
@@ -89,6 +89,12 @@ class AsyncRunner(TubeRunner):
                 "Use `process()` directly, providing required inputs to each call."
             ) from e
 
+        if self._exhausted:
+            raise GeneratorExhaustedError(
+                "Tube is exhausted: a generator node ran out of values in a previous run. "
+                "Create a new runner to run again."
+            )
+
         await self.init()
         current_iter = 0
         has_return = any(isinstance(node, Return) for node in self.tube.nodes.values())
@@ -107,6 +113,9 @@ class AsyncRunner(TubeRunner):
 
                 yield ret
                 current_iter += 1
+        except GeneratorExhaustedError:
+            self._exhausted = True
+            return
         finally:
             await self.deinit()
 

--- a/packages/noob/src/noob/runner/base.py
+++ b/packages/noob/src/noob/runner/base.py
@@ -5,7 +5,7 @@ import hashlib
 import inspect
 import threading
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Coroutine, Generator, Iterator, Sequence
+from collections.abc import Callable, Coroutine, Generator, Iterator, MutableSequence, Sequence
 from concurrent.futures import Future as ConcurrentFuture
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -19,7 +19,7 @@ from noob import Tube, init_logger
 from noob.asset import AssetScope
 from noob.edge import Edge
 from noob.event import Event, MetaEvent
-from noob.exceptions import InputMissingError
+from noob.exceptions import InputMissingError, NodeExhaustedError
 from noob.input import InputScope
 from noob.node import Node, Return
 from noob.store import EventStore
@@ -54,6 +54,8 @@ class TubeRunner(ABC):
 
     _logger: Logger = None  # type: ignore[assignment]
     _runner_id: str | None = None
+    _exhausted: bool = False
+    """When a node is exhausted, set True to prevent further process calls until re-inited"""
 
     def __post_init__(self):
         self._logger = init_logger(f"noob.runner.{self.runner_id}")
@@ -104,7 +106,10 @@ class TubeRunner(ABC):
         Runner-scoped assets are initialized and deinitialized in
         :meth:`.TubeRunner.init` and :meth:`.TubeRunner.deinit`
         """
+        if self._exhausted:
+            raise NodeExhaustedError("Tube is exhausted and can't be run until re-initialized")
         input = self._validate_input(**kwargs)
+
         with self._asset_context(AssetScope.process):
             self._before_process()
 
@@ -131,7 +136,6 @@ class TubeRunner(ABC):
           if the tube has already been started and is running,
           (i.e. :meth:`.deinit` has not been called,
           or the tube has not exhausted itself)
-
         """
 
     @abstractmethod
@@ -143,7 +147,7 @@ class TubeRunner(ABC):
 
         * Deinitialize nodes
         * Deinitialize runner-scoped assets
-
+        * Set _exhausted flag to False
         """
 
     def iter(self, n: int | None = None) -> Generator[ReturnNodeType, None, None]:
@@ -167,13 +171,13 @@ class TubeRunner(ABC):
         current_iter = 0
         has_return = any(isinstance(node, Return) for node in self.tube.nodes.values())
         try:
-            while n is None or current_iter < n:
+            while self.running and (n is None or current_iter < n):
                 ret = None
                 loop = 0
                 if not has_return:
                     ret = self.process()
                 else:
-                    while ret is None:
+                    while self.running and ret is None:
                         ret = self.process()
                         loop += 1
                         if loop > self.max_iter_loops:
@@ -181,6 +185,8 @@ class TubeRunner(ABC):
 
                 yield ret
                 current_iter += 1
+        except NodeExhaustedError:
+            self._logger.info("Iteration stopped because node was exhausted")
         finally:
             self.deinit()
 
@@ -211,12 +217,12 @@ class TubeRunner(ABC):
         if not self.running:
             self.init()
         try:
-            while n is None or current_iter < n:
+            while self.running and (n is None or current_iter < n):
                 out = self.process()
                 if out is not None:
                     outputs.append(out)
                 current_iter += 1
-        except (KeyboardInterrupt, StopIteration):
+        except (KeyboardInterrupt, StopIteration, NodeExhaustedError):
             # fine, just return
             pass
         finally:
@@ -370,6 +376,7 @@ class TubeRunner(ABC):
         * Store events to make them available to other nodes, as needed
         * Update the scheduler
         * Update the asset state
+        * Call :meth:`_handle_exhaustion` to cancel a run when a node is exhausted
         * Call any callbacks with the resultant events
 
         The base implementation
@@ -385,7 +392,17 @@ class TubeRunner(ABC):
         if node.id in self.tube.state.dependencies:
             self.tube.state.update(events)
         events_and_metaevents = self.tube.scheduler.update(events)
+        self._handle_exhaustion(events_and_metaevents)
         self._call_callbacks(events_and_metaevents)
+
+    @abstractmethod
+    def _handle_exhaustion(self, events: MutableSequence[Event | MetaEvent]) -> bool:
+        """
+        Stop a run if a node is exhausted.
+        Return True if a node was exhausted, False otherwise.
+        Set the `_exhausted` flag to True
+        """
+        pass
 
     @contextmanager
     def _asset_context(self, scope: AssetScope, edges: list[Edge] | None = None) -> Iterator[None]:

--- a/packages/noob/src/noob/runner/base.py
+++ b/packages/noob/src/noob/runner/base.py
@@ -19,7 +19,7 @@ from noob import Tube, init_logger
 from noob.asset import AssetScope
 from noob.edge import Edge
 from noob.event import Event, MetaEvent
-from noob.exceptions import InputMissingError
+from noob.exceptions import GeneratorExhaustedError, InputMissingError
 from noob.input import InputScope
 from noob.node import Node, Return
 from noob.store import EventStore
@@ -51,6 +51,7 @@ class TubeRunner(ABC):
     """The max number of times that `iter` will call `process` to try and get a result"""
 
     _callbacks: list[Callable[[Event | MetaEvent], None]] = field(default_factory=list)
+    _exhausted: bool = field(default=False)
 
     _logger: Logger = None  # type: ignore[assignment]
     _runner_id: str | None = None
@@ -163,6 +164,12 @@ class TubeRunner(ABC):
                 "Use `process()` directly, providing required inputs to each call."
             ) from e
 
+        if self._exhausted:
+            raise GeneratorExhaustedError(
+                "Tube is exhausted: a generator node ran out of values in a previous run. "
+                "Create a new runner to run again."
+            )
+
         self.init()
         current_iter = 0
         has_return = any(isinstance(node, Return) for node in self.tube.nodes.values())
@@ -181,6 +188,9 @@ class TubeRunner(ABC):
 
                 yield ret
                 current_iter += 1
+        except GeneratorExhaustedError:
+            self._exhausted = True
+            return
         finally:
             self.deinit()
 
@@ -206,6 +216,13 @@ class TubeRunner(ABC):
                 "that was not provided when instantiating the tube! "
                 "Use `process()` directly, providing required inputs to each call."
             ) from e
+
+        if self._exhausted:
+            raise GeneratorExhaustedError(
+                "Tube is exhausted: a generator node ran out of values in a previous run. "
+                "Create a new runner to run again."
+            )
+
         outputs = []
         current_iter = 0
         if not self.running:
@@ -219,6 +236,8 @@ class TubeRunner(ABC):
         except (KeyboardInterrupt, StopIteration):
             # fine, just return
             pass
+        except GeneratorExhaustedError:
+            self._exhausted = True
         finally:
             self.deinit()
 

--- a/packages/noob/src/noob/runner/base.py
+++ b/packages/noob/src/noob/runner/base.py
@@ -19,7 +19,7 @@ from noob import Tube, init_logger
 from noob.asset import AssetScope
 from noob.edge import Edge
 from noob.event import Event, MetaEvent
-from noob.exceptions import GeneratorExhaustedError, InputMissingError
+from noob.exceptions import InputMissingError
 from noob.input import InputScope
 from noob.node import Node, Return
 from noob.store import EventStore
@@ -51,7 +51,6 @@ class TubeRunner(ABC):
     """The max number of times that `iter` will call `process` to try and get a result"""
 
     _callbacks: list[Callable[[Event | MetaEvent], None]] = field(default_factory=list)
-    _exhausted: bool = field(default=False)
 
     _logger: Logger = None  # type: ignore[assignment]
     _runner_id: str | None = None
@@ -164,12 +163,6 @@ class TubeRunner(ABC):
                 "Use `process()` directly, providing required inputs to each call."
             ) from e
 
-        if self._exhausted:
-            raise GeneratorExhaustedError(
-                "Tube is exhausted: a generator node ran out of values in a previous run. "
-                "Create a new runner to run again."
-            )
-
         self.init()
         current_iter = 0
         has_return = any(isinstance(node, Return) for node in self.tube.nodes.values())
@@ -188,9 +181,6 @@ class TubeRunner(ABC):
 
                 yield ret
                 current_iter += 1
-        except GeneratorExhaustedError:
-            self._exhausted = True
-            return
         finally:
             self.deinit()
 
@@ -216,13 +206,6 @@ class TubeRunner(ABC):
                 "that was not provided when instantiating the tube! "
                 "Use `process()` directly, providing required inputs to each call."
             ) from e
-
-        if self._exhausted:
-            raise GeneratorExhaustedError(
-                "Tube is exhausted: a generator node ran out of values in a previous run. "
-                "Create a new runner to run again."
-            )
-
         outputs = []
         current_iter = 0
         if not self.running:
@@ -236,8 +219,6 @@ class TubeRunner(ABC):
         except (KeyboardInterrupt, StopIteration):
             # fine, just return
             pass
-        except GeneratorExhaustedError:
-            self._exhausted = True
         finally:
             self.deinit()
 

--- a/packages/noob/src/noob/runner/sync.py
+++ b/packages/noob/src/noob/runner/sync.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import MutableSequence
 from dataclasses import dataclass
 from threading import Event as ThreadEvent
 from typing import Any
 
 from noob.asset import AssetScope
-from noob.event import MetaEvent
+from noob.event import Event, MetaEvent, MetaSignal
+from noob.exceptions import NodeExhaustedError
 from noob.node import Return
 from noob.runner.base import TubeRunner, call_async_from_sync
 from noob.scheduler import Scheduler
@@ -47,6 +49,7 @@ class SynchronousRunner(TubeRunner):
     def deinit(self) -> None:
         """Stop all nodes processing"""
         # TODO: lock to ensure we've been started
+        self._exhausted = False
         for node in self.tube.enabled_nodes.values():
             node_deinit = self.inject_context(node.deinit)
             if iscoroutinefunction_partial(node_deinit):
@@ -110,3 +113,15 @@ class SynchronousRunner(TubeRunner):
             return None
         ret_node = ret_nodes[0]
         return ret_node.get(keep=False)
+
+    def _handle_exhaustion(self, events: MutableSequence[Event | MetaEvent]) -> bool:
+        """Clear the self._running flag to stop a run"""
+        for e in events:
+            if e["value"] is MetaSignal.Exhausted:
+                self._running.clear()
+                self._exhausted = True
+
+                raise NodeExhaustedError(f"Node {e['node_id']} is exhausted")
+
+                # return True
+        return False

--- a/packages/noob/src/noob/runner/zmq/runner.py
+++ b/packages/noob/src/noob/runner/zmq/runner.py
@@ -11,7 +11,7 @@ from time import time
 from typing import Any, cast, overload
 
 from noob.event import Event, MetaEvent, MetaEventType, MetaSignal
-from noob.exceptions import InputMissingError
+from noob.exceptions import InputMissingError, NodeExhaustedError
 from noob.input import InputScope
 from noob.network.message import ErrorMsg, ErrorValue, EventMsg, Message, MessageType
 from noob.node import Return
@@ -176,6 +176,8 @@ class ZMQRunner(TubeRunner):
             raise RuntimeError(
                 "Runner is already running in free run mode! use iter to gather results"
             )
+        if self._exhausted:
+            raise NodeExhaustedError("Tube is exhausted and can't be run again until re-inited")
         input = self.tube.input_collection.validate_input(InputScope.process, kwargs)
         self._running.set()
         try:
@@ -245,7 +247,7 @@ class ZMQRunner(TubeRunner):
         self._running.set()
         current_iter = 0
         try:
-            while n is None or current_iter < n:
+            while self.running and (n is None or current_iter < n):
                 ret = MetaSignal.NoEvent
                 loop = 0
                 while ret is MetaSignal.NoEvent:
@@ -266,6 +268,8 @@ class ZMQRunner(TubeRunner):
 
                 current_iter += 1
                 yield ret
+        except NodeExhaustedError:
+            self._logger.info("Iteration stopped because node was exhausted")
 
         finally:
             self.stop()
@@ -369,6 +373,9 @@ class ZMQRunner(TubeRunner):
                     with self._epoch_condition:
                         events.extend(self.tube.scheduler.expire(epoch, self._return_node.id))
 
+        if self._handle_exhaustion(events):
+            self.stop()
+
         ended = [
             e for e in events if e["node_id"] == "meta" and e["signal"] == MetaEventType.EpochEnded
         ]
@@ -383,6 +390,10 @@ class ZMQRunner(TubeRunner):
         for e in ended:
             if len(e["value"]) == 1:
                 await self.command.epoch_ended(e["value"])
+
+        for cb in self._callbacks:
+            for e in events:
+                cb(e)
 
     def on_router(self, msg: Message) -> None:
         if isinstance(msg, ErrorMsg):
@@ -412,11 +423,16 @@ class ZMQRunner(TubeRunner):
                 self.store.clear(epoch)
             return ret
 
-    def _handle_error(self, msg: ErrorMsg) -> None:
+    def _handle_error(self, msg: ErrorMsg | Exception) -> None:
         """Cancel current epoch, stash error for process method to throw"""
         self._logger.error("Received error from node: %s", msg)
-        exception = msg.to_exception()
-        self._to_throw = msg.value
+        if isinstance(msg, ErrorMsg):
+            exception = msg.to_exception()
+            self._to_throw = msg.value
+        else:
+            exception = msg
+            self._to_throw = msg
+
         if self._current_epoch is not None:
             # if we're waiting in the process method,
             # end epoch and raise error there
@@ -477,3 +493,13 @@ class ZMQRunner(TubeRunner):
             self._epoch_futures[epoch].set_result(epoch)
 
         return self._epoch_futures[epoch]
+
+    def _handle_exhaustion(self, events: MutableSequence[Event | MetaEvent]) -> bool:
+        for e in events:
+            if e["value"] is MetaSignal.Exhausted:
+                with self._running_lock:
+                    self._running.clear()
+                    self._exhausted = True
+                self._handle_error(NodeExhaustedError(f"Node {e['node_id']} is exhausted!"))
+                return True
+        return False

--- a/packages/noob/src/noob/scheduler.py
+++ b/packages/noob/src/noob/scheduler.py
@@ -375,7 +375,7 @@ class Scheduler:
             if (e["node_id"], e["signal"]) not in self.graph_signals:
                 continue
 
-            if e["value"] is MetaSignal.NoEvent:
+            if e["value"] is MetaSignal.NoEvent or e["value"] is MetaSignal.Exhausted:
                 end_events.extend(
                     self.expire(epoch=e["epoch"], node_id=e["node_id"], signal=e["signal"])
                 )

--- a/packages/noob/tests/data/pipelines/special/exhaustion.yaml
+++ b/packages/noob/tests/data/pipelines/special/exhaustion.yaml
@@ -1,0 +1,13 @@
+noob_id: testing-exhaustion
+noob_model: noob.tube.TubeSpecification
+noob_version: 0.0.1
+description: |
+  A tube with a generator that exhausts after 3 epochs
+nodes:
+  a:
+    type: noob.testing.count_source
+    params:
+      limit: 3
+  c:
+    type: return
+    depends: a.index

--- a/packages/noob/tests/test_pipelines/test_exhaustion.py
+++ b/packages/noob/tests/test_pipelines/test_exhaustion.py
@@ -1,0 +1,87 @@
+"""
+All runners should handle node exhaustion!
+"""
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from noob.exceptions import NodeExhaustedError
+from noob.runner import AsyncRunner
+from noob.runner.zmq import ZMQRunner
+from noob.utils import iscoroutinefunction_partial
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("loaded_tube", ["testing-exhaustion"], indirect=True)
+async def test_exhaustion_process(loaded_tube, all_runners):
+    """
+    Runners should handle node exhaustion by erroring on process calls after exhaustion
+    """
+    runner = all_runners
+    # first ones should work fine
+    for _ in range(3):
+        if iscoroutinefunction_partial(runner.process):
+            res = await runner.process()
+        else:
+            res = runner.process()
+
+    # the next one should raise
+    with pytest.raises(NodeExhaustedError):
+        if iscoroutinefunction_partial(runner.process):
+            res = await runner.process()
+        else:
+            res = runner.process()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("loaded_tube", ["testing-exhaustion"], indirect=True)
+async def test_exhaustion_iter(loaded_tube, all_runners):
+    """
+    Runners should stop iteration on node exhaustion
+    """
+    results = []
+    runner = all_runners
+    if iscoroutinefunction_partial(runner.iter):
+        async for result in runner.iter():
+            results.append(result)
+    else:
+        for result in runner.iter():
+            results.append(result)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("loaded_tube", ["testing-exhaustion"], indirect=True)
+async def test_exhaustion_run(loaded_tube, all_runners):
+    """
+    Runners should stop running on node exhaustion
+    """
+    runner = all_runners
+    if isinstance(runner, ZMQRunner):
+        runner.autoclear_store = False
+    elif isinstance(runner, AsyncRunner) and not iscoroutinefunction_partial(runner.run):
+        pytest.xfail("Need to implement run method on async runner")
+
+    results = []
+
+    def store_result(event: Any) -> None:
+        nonlocal results
+        results.append(event)
+
+    runner.add_callback(store_result)
+
+    if iscoroutinefunction_partial(runner.run):
+        await runner.run()
+    else:
+        runner.run()
+
+    if isinstance(runner, ZMQRunner):
+        # zmqrunner doesn't block on run
+        stop_waiting = time.time() + 5
+        while time.time() < stop_waiting and runner.running:
+            await asyncio.sleep(0.1)
+
+    a_events = [r for r in results if r["node_id"] == "a"]
+    assert len(a_events) == 3


### PR DESCRIPTION
A draft of fixing #147 - but we should not merge this, in working on this i realized that our stopping logic in general needs some work, related to #206 as well.

So this was part of the "see if fable can actually do stuff" test run, the initial commit is its attempt and called it good. clearly that is inadequate. 

mine adds handling exhaustion as an event but is similarly hacky - the things we need are
- #247 - better control over initialization condition, we need a general way to shut it down and exist from whatever run is happening.
- move the event handling into the scheduler, so the scheduler is the thing that says "can't run anymore bub" - so rather than a million different handlers in the different runners, if the scheduler comes across an exhaustion event, it yields the remaining nodes that can run, and then future calls to the ready iterators raise an exception that says "can't run no more"
- more coherent hook handling in general across the runners - we could do with a bit of cleanup, they are sort of diverging from one another and the hook methods aren't actually usable because of that divergence. each of the runners does have a different design, but still it shouldn't be this hard to handle an event.

opening this up as a draft, but we should fix the other things first, and i'll need to think about how we want to handle this in the scheduler.

<!-- readthedocs-preview noob start -->
----
📚 Documentation preview 📚: https://noob--248.org.readthedocs.build/en/248/

<!-- readthedocs-preview noob end -->